### PR TITLE
Avoid too fast(slow) client.Connect

### DIFF
--- a/LadderManager.cpp
+++ b/LadderManager.cpp
@@ -690,7 +690,7 @@ ResultType LadderManager::StartGame(BotConfig Agent1, BotConfig Agent2, std::str
 	sc2::SleepFor(5000);
 	while (GameRunning)
 	{
-		auto update1status = bot1UpdateThread.wait_for(1ms);
+		auto update1status = bot1UpdateThread.wait_for(1s);
 		auto update2status = bot2UpdateThread.wait_for(0ms);
 		auto thread1Status = bot1ProgramThread.wait_for(0ms);
 		auto thread2Status = bot2ProgramThread.wait_for(0ms);

--- a/LadderManager.cpp
+++ b/LadderManager.cpp
@@ -591,15 +591,32 @@ ResultType LadderManager::StartGame(BotConfig Agent1, BotConfig Agent2, std::str
 		"-displayMode", "0",
 		"-dataVersion", process_settings.data_version }
 	);
-	sc2::SleepFor(10000);
 
 	// Connect to running sc2 process.
 	sc2::Connection client;
-	client.Connect("127.0.0.1", 5679);
+	int connectionAttemptsClient1 = 0;
+	while (!client.Connect("127.0.0.1", 5679))
+	{
+		connectionAttemptsClient1++;
+		sc2::SleepFor(1000);
+		if (connectionAttemptsClient1 > 60)
+		{
+			std::cout << "Failed to connect client 1. BotProcessID: " << Bot1ProcessId << std::endl;
+			return ResultType::InitializationError;
+		}
+	}
 	sc2::Connection client2;
-	client2.Connect("127.0.0.1", 5680);
-
-
+	int connectionAttemptsClient2 = 0;
+	while (!client2.Connect("127.0.0.1", 5680))
+	{
+		connectionAttemptsClient2++;
+		sc2::SleepFor(1000);
+		if (connectionAttemptsClient2 > 60)
+		{
+			std::cout << "Failed to connect client 2. BotProcessID: " << Bot2ProcessId << std::endl;
+			return ResultType::InitializationError;
+		}
+	}
 
 	std::vector<sc2::PlayerSetup> Players;
 

--- a/LadderManager.cpp
+++ b/LadderManager.cpp
@@ -90,7 +90,7 @@ bool ProcessResponse(const SC2APIProtocol::ResponseCreateGame& response)
 }
 
 
-ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server)
+ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server,std::string *botName)
 {
 	//    std::cout << "Sending Join game request" << std::endl;
 	//    sc2::GameRequestPtr Create_game_request = CreateJoinGameRequest();
@@ -142,7 +142,7 @@ ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server)
 				if (response != nullptr)
 				{
 					CurrentStatus = response->status();
-					std::cout <<"Current status: "<< status.at(CurrentStatus) << std::endl;
+					std::cout <<"Current status of "<<*botName<<": "<< status.at(CurrentStatus) << std::endl;
 					if (CurrentStatus > SC2APIProtocol::Status::in_replay)
 					{
 						CurrentExitCase = ExitCase::GameEnd;
@@ -523,7 +523,7 @@ ResultType LadderManager::StartGameVsDefault(BotConfig Agent1, sc2::Race CompRac
 	auto bot1ProgramThread = std::thread(StartBotProcess, Agent1Path);
 	std::vector<sc2::PlayerResult> Player1Results;
 
-	auto bot1UpdateThread = std::async(GameUpdate, &client, &server);
+	auto bot1UpdateThread = std::async(GameUpdate, &client, &server,&Agent1.Name);
 	ResultType CurrentResult = ResultType::InitializationError;
 	bool GameRunning = true;
 	sc2::ProtoInterface proto_1;
@@ -649,24 +649,24 @@ ResultType LadderManager::StartGame(BotConfig Agent1, BotConfig Agent2, std::str
 	}
 	std::cout << "Starting bot: " << Agent1.Name << std::endl;
 	auto bot1ProgramThread = std::async(&StartBotProcess, Agent1Path);
-	sc2::SleepFor(1000);
+	sc2::SleepFor(2000);
 
 	std::cout << "Monitoring client of: " << Agent1.Name << std::endl;
-	auto bot1UpdateThread = std::async(&GameUpdate, &client, &server);
-	sc2::SleepFor(1000);
+	auto bot1UpdateThread = std::async(&GameUpdate, &client, &server, &Agent1.Name);
+	sc2::SleepFor(2000);
 
 	std::cout << std::endl << "Starting bot: " << Agent2.Name << std::endl;
 	auto bot2ProgramThread = std::async(&StartBotProcess, Agent2Path);
-	sc2::SleepFor(1000);
+	sc2::SleepFor(2000);
 
 	std::cout << "Monitoring client of: " << Agent2.Name << std::endl;
-	auto bot2UpdateThread = std::async(&GameUpdate, &client2, &server2);
-	sc2::SleepFor(1000);
+	auto bot2UpdateThread = std::async(&GameUpdate, &client2, &server2, &Agent2.Name);
+	sc2::SleepFor(2000);
 
 	ResultType CurrentResult = ResultType::InitializationError;
 	bool GameRunning = true;
 	//sc2::ProtoInterface proto_1;
-	sc2::SleepFor(10000);
+	sc2::SleepFor(1200000);
 	while (GameRunning)
 	{
 		auto update1status = bot1UpdateThread.wait_for(1s);


### PR DESCRIPTION
If the connect call is too fast it fails and the LadderManager crashes. On some machines 10sec waiting is not enough. Other machines could connect faster. So I put the connection attempts in a while loop and after 60 failed attempts it gives an error message instead of crashing.

Regards