### PR TITLE
stderr to file, working directory = rootPath for bots, relative paths

### DIFF
--- a/LadderManager.cpp
+++ b/LadderManager.cpp
@@ -167,7 +167,7 @@ ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server,std::string *bo
 				}
 
 				// Send the response back to the client.
-				if (server->connections_.size() > 0)
+				if (server->connections_.size() > 0 && client->connection_ != NULL)
 				{
 					server->QueueResponse(client->connection_, response);
 					server->SendResponse();
@@ -183,7 +183,7 @@ ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server,std::string *bo
 			{
 				if ((LastRequest + (50 * CLOCKS_PER_SEC)) < clock())
 				{
-					std::cout << "Client timeout" << std::endl;
+					std::cout << "Client timeout(" << *botName <<")" << std::endl;
 					CurrentExitCase = ExitCase::ClientTimeout;
 				}
 			}
@@ -226,35 +226,64 @@ bool LadderManager::SaveReplay(sc2::Connection *client, const std::string& path)
 }
 
 
-void StartBotProcess(std::string CommandLine)
+void StartBotProcess(BotConfig Agent, std::string CommandLine)
 {
 	//////////////////////////////////////////////////////////////////////////////////////////////////
 	// Executes the given command using CreateProcess() and WaitForSingleObject().
 	// Returns FALSE if the command could not be executed or if the exit code could not be determined.
-	PROCESS_INFORMATION processInformation = { 0 };
-	STARTUPINFO startupInfo = { 0 };
-	DWORD exitCode;
-	startupInfo.cb = sizeof(startupInfo);
-	LPSTR cmdLine = const_cast<char *>(CommandLine.c_str());
 
+	SECURITY_ATTRIBUTES securityAttributes;
+	securityAttributes.nLength = sizeof(securityAttributes);
+	securityAttributes.lpSecurityDescriptor = NULL;
+	securityAttributes.bInheritHandle = TRUE;
+	std::string logFile = Agent.RootPath + "/stderr.log";
+	HANDLE h = CreateFile(logFile.c_str(),
+		FILE_APPEND_DATA,
+		FILE_SHARE_WRITE | FILE_SHARE_READ,
+		&securityAttributes,
+		OPEN_ALWAYS,
+		FILE_ATTRIBUTE_NORMAL,
+		NULL);
+
+	PROCESS_INFORMATION processInformation;
+	STARTUPINFO startupInfo;
+	DWORD flags = NORMAL_PRIORITY_CLASS | CREATE_NEW_CONSOLE; //CREATE_NO_WINDOW <-- also possible, but we don't see easily if bot is still running.
+
+	ZeroMemory(&processInformation, sizeof(PROCESS_INFORMATION));
+	ZeroMemory(&startupInfo, sizeof(STARTUPINFO));
+	startupInfo.cb = sizeof(STARTUPINFO);
+	startupInfo.dwFlags |= STARTF_USESTDHANDLES;
+	startupInfo.hStdInput = INVALID_HANDLE_VALUE;
+	startupInfo.hStdError = h;
+	startupInfo.hStdOutput = NULL;
+
+	DWORD exitCode;
+	LPSTR cmdLine = const_cast<char *>(CommandLine.c_str());
 	// Create the process
 
 	BOOL result = CreateProcess(NULL, cmdLine,
-		NULL, NULL, FALSE,
-		NORMAL_PRIORITY_CLASS | CREATE_NEW_CONSOLE,
-		NULL, NULL, &startupInfo, &processInformation);
+		NULL, NULL, TRUE,
+		flags,
+		NULL, Agent.RootPath.c_str(), &startupInfo, &processInformation);
 
 
 	if (!result)
 	{
-		// CreateProcess() failed
 		// Get the error from the system
-		LPVOID lpMsgBuf;
+		LPSTR lpMsgBuf;
 		DWORD dw = GetLastError();
-		FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+		size_t size = FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
 			NULL, dw, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&lpMsgBuf, 0, NULL);
 
-
+		std::string message(lpMsgBuf, size);
+		{
+			static std::mutex m;
+			std::lock_guard<std::mutex> mylock(m);
+			std::cout << "Starting bot: " << Agent.BotName << " with command:" << std::endl;
+			std::cout << CommandLine << std::endl;
+			std::cout << "...failed" << std::endl;
+			std::cout << "Error " << dw << " : " << message << std::endl;
+		}
 		// Free resources created by the system
 		LocalFree(lpMsgBuf);
 
@@ -263,6 +292,13 @@ void StartBotProcess(std::string CommandLine)
 	}
 	else
 	{
+		{
+			static std::mutex m;
+			std::lock_guard<std::mutex> mylock(m);
+			std::cout << "Starting bot: " << Agent.BotName << " with command:" << std::endl;
+			std::cout << CommandLine << std::endl;
+			std::cout << "...success!" << std::endl;
+		}
 		// Successfully created the process.  Wait for it to finish.
 		WaitForSingleObject(processInformation.hProcess, INFINITE);
 
@@ -279,9 +315,9 @@ void StartBotProcess(std::string CommandLine)
 			exitCode = -1;
 		}
 
-
 		// We succeeded.
 	}
+	CloseHandle(h);
 }
 
 BOOL KillSc2Process(DWORD dwProcessId, UINT uExitCode)
@@ -319,7 +355,7 @@ std::string LadderManager::GetBotCommandLine(BotConfig AgentConfig, int GamePort
 	{
 	case Python:
 	{
-		OutCmdLine = "python " + AgentConfig.RootPath + AgentConfig.FileName;
+		OutCmdLine = "python " + AgentConfig.FileName;
 		break;
 	}
 	case BinaryCpp:
@@ -329,7 +365,7 @@ std::string LadderManager::GetBotCommandLine(BotConfig AgentConfig, int GamePort
 	}
 	case CommandCenter:
 	{
-		OutCmdLine = Config->GetValue("CommandCenterPath") + " --ConfigFile " + AgentConfig.RootPath;
+		OutCmdLine = Config->GetValue("CommandCenterPath") + " --ConfigFile " + AgentConfig.FileName;
 		break;
 
 	}
@@ -547,8 +583,7 @@ ResultType LadderManager::StartGameVsDefault(BotConfig Agent1, sc2::Race CompRac
 		}
 	}
 
-	std::cout << "Starting bot: " << Agent1.BotName << std::endl;
-	auto bot1ProgramThread = std::thread(StartBotProcess, Agent1Path);
+	auto bot1ProgramThread = std::thread(StartBotProcess,Agent1,Agent1Path);
 	sc2::SleepFor(1000);
 
 	std::cout << "Monitoring client of: " << Agent1.BotName << std::endl;
@@ -681,13 +716,12 @@ ResultType LadderManager::StartGame(BotConfig Agent1, BotConfig Agent2, std::str
 			std::cout << "Create game successful" << std::endl << std::endl;
 		}
 	}
-	std::cout << "Starting bot: " << Agent1.BotName << " with command:"<<std::endl;
-	std::cout << Agent1Path << std::endl;
-	auto bot1ProgramThread = std::async(&StartBotProcess, Agent1Path);
-	std::cout << "Starting bot: " << Agent2.BotName << " with command:" << std::endl;
-	std::cout << Agent2Path << std::endl;
-	auto bot2ProgramThread = std::async(&StartBotProcess, Agent2Path);
-	sc2::SleepFor(1000);
+	auto bot1ProgramThread = std::async(&StartBotProcess, Agent1, Agent1Path);
+	auto bot2ProgramThread = std::async(&StartBotProcess, Agent2, Agent2Path);
+	sc2::SleepFor(500);
+	sc2::SleepFor(500);
+
+	//toDo check here already if the bots crashed.
 
 	auto bot1UpdateThread = std::async(&GameUpdate, &client, &server, &Agent1.BotName);
 	auto bot2UpdateThread = std::async(&GameUpdate, &client2, &server2, &Agent2.BotName);

--- a/LadderManager.h
+++ b/LadderManager.h
@@ -1,8 +1,25 @@
 #pragma once
 #include <memory.h>
+#include <sstream>
+#include <mutex>
 #define MAX_GAME_TIME 60480
 #define PORT_START 5690
 
+
+class PrintThread : public std::ostringstream
+{
+public:
+	PrintThread() = default;
+
+	~PrintThread()
+	{
+		std::lock_guard<std::mutex> guard(_mutexPrint);
+		std::cout << this->str();
+	}
+
+private:
+	static std::mutex _mutexPrint;
+};
 
 class LadderManager
 {


### PR DESCRIPTION
I am a bit unsure with some of the things I am doing.

- SECURITY_ATTRIBUTES no idea
- Flag for also stdout? Probably not.
- How can the bot.exe be contained to its working space and subfolders? Could a bot.exe say format c: ? This should be a different issue/PR imo, however.

I have uploaded a [precompiled version of the LadderManager](https://drive.google.com/open?id=18lmZEzzZEP1VhqmHKsiSn9g7P2BDutNJ) with the changes and all current ladderbots + pysc2/python-sc2/c# example. The first two obviously only work if the frameworks are installed. Otherwise it should work out-of-the-box by executing the ladderManager. (You maybe need to whitelist some of the CC bot based bots :) )

Please ignore the failed rebase....