### PR TITLE
Disable curl via cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,10 @@ cmake_minimum_required(VERSION 3.6)
 project(Sc2LadderServer)
 
 # Allow option to disable curl via cmake option
-OPTION(DISABLE_CURL "Disable Curl" ON)
-IF(DISABLE_CURL)
-    ADD_DEFINITIONS(-DDISABLE_CURL)
-ENDIF(DISABLE_CURL)
+OPTION(ENABLE_CURL "Enable Curl" OFF)
+IF(ENABLE_CURL)
+    ADD_DEFINITIONS(-DENABLE_CURL)
+ENDIF(ENABLE_CURL)
 
 # Use bin as the directory for all executables.
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.6)
 
 project(Sc2LadderServer)
 
+# Allow option to disable curl via cmake option
+OPTION(DISABLE_CURL "Disable Curl" OFF)
+IF(DISABLE_CURL)
+    ADD_DEFINITIONS(-DDISABLE_CURL)
+ENDIF(DISABLE_CURL)
+
 # Use bin as the directory for all executables.
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.6)
 project(Sc2LadderServer)
 
 # Allow option to disable curl via cmake option
-OPTION(DISABLE_CURL "Disable Curl" OFF)
+OPTION(DISABLE_CURL "Disable Curl" ON)
 IF(DISABLE_CURL)
     ADD_DEFINITIONS(-DDISABLE_CURL)
 ENDIF(DISABLE_CURL)

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ $ cd build
 
 :: Generate VS solution.
 $ cmake ../ -G "Visual Studio 15 2017 Win64"
-:: Or to disable curl (recommended for most users):
-$ cmake -DDISABLE_CURL=ON ../ -G "Visual Studio 15 2017 Win64"
 
 :: Build the project using Visual Studio.
 $ start Sc2LadderServer.sln
@@ -55,8 +53,6 @@ $ start Sc2LadderServer.sln
  
  # Generate a Makefile.
  $ cmake ../
- # Or to disable curl (recommended for most users):
- $ cmake -DDISABLE_CURL=ON ../
  
  # Build.
  $ make
@@ -69,6 +65,12 @@ git submodule update --init --recursive
 ```
 Alternatively, you could opt to symlink the folder of the submodule in question to an existing copy already on your computer. However, note that you will very likely be using a different version of the submodule to that which would otherwise be downloaded in this repository, which could cause issues (but it's probably not too likely). 
  
+### CMake options
+
+| Option | Default | Description |
+|---|---|---|
+| `DISABLE_CURL`	    	| ON |	Disable curl reliant features. e.g. website connectivity. |
+
 ## Configuration
 
 ### Maps

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Alternatively, you could opt to symlink the folder of the submodule in question 
 
 | Option | Default | Description |
 |---|---|---|
-| `DISABLE_CURL`	    	| ON |	Disable curl reliant features. e.g. website connectivity. |
+| `ENABLE_CURL`	    	| OFF |	Enable curl reliant features. e.g. website connectivity. |
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ $ cd build
 
 :: Generate VS solution.
 $ cmake ../ -G "Visual Studio 15 2017 Win64"
+:: Or to disable curl (recommended for most users):
+$ cmake -DDISABLE_CURL=ON ../ -G "Visual Studio 15 2017 Win64"
 
 :: Build the project using Visual Studio.
 $ start Sc2LadderServer.sln
@@ -53,6 +55,8 @@ $ start Sc2LadderServer.sln
  
  # Generate a Makefile.
  $ cmake ../
+ # Or to disable curl (recommended for most users):
+ $ cmake -DDISABLE_CURL=ON ../
  
  # Build.
  $ make

--- a/example_configs/LadderManager.conf
+++ b/example_configs/LadderManager.conf
@@ -5,6 +5,6 @@ MaxGameTime=60480
 MatchupListFile=.\matchuplist
 ErrorListFile=.\errorlist
 BotConfigFile=.\LadderBots.json
-EnableReplayUpload=True
+EnableReplayUpload=False
 ResultsLogFile=.\Results.json
 PlayerIdFile=.\playerids

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(SYSTEM
 # Link directories
 link_directories(${PROJECT_BINARY_DIR} ${PROJECT_BINARY_DIR}/s2client-api/bin)
 
-if(NOT DISABLE_CURL AND WIN32) # Curl library for windows
+if(ENABLE_CURL AND WIN32) # Curl library for windows
     include_directories(SYSTEM
             ${PROJECT_SOURCE_DIR}/curl/include/curl
     )
@@ -31,7 +31,7 @@ target_link_libraries(Sc2LadderCore
     sc2api sc2lib sc2utils sc2protocol civetweb libprotobuf
 )
 
-if(NOT DISABLE_CURL)
+if(ENABLE_CURL)
     if (WIN32) # Platform specific curl library
         target_link_libraries(Sc2LadderCore libcurl.lib)
         # todo: check for debug/release and copy only relevant DLL

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,18 +9,16 @@ include_directories(SYSTEM
     ${PROJECT_SOURCE_DIR}/s2client-api/contrib/protobuf/src
     ${PROJECT_BINARY_DIR}/s2client-api/generated
     ${PROJECT_SOURCE_DIR}/rapidjson
-	if (WIN32) # Curl include for windows
-		include_directories(SYSTEM
-				${PROJECT_SOURCE_DIR}/curl/include/curl
-		)
-	endif ()
 )
 
 # Link directories
 link_directories(${PROJECT_BINARY_DIR} ${PROJECT_BINARY_DIR}/s2client-api/bin)
 
-if (WIN32) # Curl library for windows
-	link_directories(${PROJECT_SOURCE_DIR}/curl/lib)
+if(NOT DISABLE_CURL AND WIN32) # Curl library for windows
+    include_directories(SYSTEM
+            ${PROJECT_SOURCE_DIR}/curl/include/curl
+    )
+    link_directories(${PROJECT_SOURCE_DIR}/curl/lib)
 endif ()
 
 # Create the executable.
@@ -32,20 +30,19 @@ target_link_libraries(Sc2LadderServer
 target_link_libraries(Sc2LadderCore
     sc2api sc2lib sc2utils sc2protocol civetweb libprotobuf
 )
-if (WIN32) # Platform specific curl library
-	target_link_libraries(Sc2LadderCore libcurl.lib)
-elseif (UNIX)
-	target_link_libraries(Sc2LadderCore curl)
-endif ()
 
-
-if (WIN32) # Curl dlls for windows
-	# todo: check for debug/release and copy only relevant DLL
-	# todo: currently it copies both the debug and release DLLs regardless
-	add_custom_command(TARGET Sc2LadderServer POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_directory
-			"${PROJECT_SOURCE_DIR}/curl/bin/"
-			$<TARGET_FILE_DIR:Sc2LadderServer>)
+if(NOT DISABLE_CURL)
+    if (WIN32) # Platform specific curl library
+        target_link_libraries(Sc2LadderCore libcurl.lib)
+        # todo: check for debug/release and copy only relevant DLL
+        # todo: currently it copies both the debug and release DLLs regardless
+        add_custom_command(TARGET Sc2LadderServer POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                "${PROJECT_SOURCE_DIR}/curl/bin/"
+                $<TARGET_FILE_DIR:Sc2LadderServer>)
+    elseif (UNIX)
+        target_link_libraries(Sc2LadderCore curl)
+    endif ()
 endif ()
 
 # Set working directory as the project root

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -862,8 +862,9 @@ bool LadderManager::LoadSetup()
 	if (EnableReplayUploadString == "True")
 	{
 #ifdef DISABLE_CURL
-        throw std::logic_error(
-                "ERROR: Project was compiled with DISABLE_CURL but ladder manager is configured with EnableReplayUpload=True!");
+		throw std::logic_error(
+				"ERROR: Project was compiled with DISABLE_CURL but ladder manager is configured with EnableReplayUpload=True!"
+				" Either set EnableReplayUpload to False in the ladder configuration or run CMake with DISABLE_CURL set to OFF");
 #else
         EnableReplayUploads = true;
 #endif
@@ -875,8 +876,9 @@ bool LadderManager::LoadSetup()
 	if (EnableServerLoginString == "True")
 	{
 #ifdef DISABLE_CURL
-        throw std::logic_error(
-                "ERROR: Project was compiled with DISABLE_CURL but ladder manager is configured with EnableServerLoginString=True!");
+		throw std::logic_error(
+				"ERROR: Project was compiled with DISABLE_CURL but ladder manager is configured with EnableServerLogin=True!"
+				" Either set EnableServerLogin to False in the ladder configuration or run CMake with DISABLE_CURL set to OFF");
 #else
         EnableServerLogin = true;
 		ServerLoginAddress = Config->GetValue("ServerLoginAddress");

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -30,7 +30,6 @@
 #include <iostream>
 #include <future>
 #include <chrono>
-#include "curl.h"
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sstream>   
@@ -40,6 +39,10 @@
 #include "LadderManager.h"
 #include "MatchupList.h"
 #include "Tools.h"
+
+#ifndef DISABLE_CURL
+#include "curl.h"
+#endif
 
 std::mutex PrintThread::_mutexPrint{};
 

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -861,11 +861,12 @@ bool LadderManager::LoadSetup()
 	std::string EnableReplayUploadString = Config->GetValue("EnableReplayUpload");
 	if (EnableReplayUploadString == "True")
 	{
-	    #ifdef DISABLE_CURL
-	    throw std::logic_error("ERROR: Project was compiled with DISABLE_CURL but ladder manager is configured with EnableReplayUpload=True!");
-        #else
+#ifdef DISABLE_CURL
+        throw std::logic_error(
+                "ERROR: Project was compiled with DISABLE_CURL but ladder manager is configured with EnableReplayUpload=True!");
+#else
         EnableReplayUploads = true;
-        #endif
+#endif
 	}
 
 	ResultsLogFile = Config->GetValue("ResultsLogFile");

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -874,10 +874,15 @@ bool LadderManager::LoadSetup()
 	std::string EnableServerLoginString = Config->GetValue("EnableServerLogin");
 	if (EnableServerLoginString == "True")
 	{
-		EnableServerLogin = true;
+#ifdef DISABLE_CURL
+        throw std::logic_error(
+                "ERROR: Project was compiled with DISABLE_CURL but ladder manager is configured with EnableServerLoginString=True!");
+#else
+        EnableServerLogin = true;
 		ServerLoginAddress = Config->GetValue("ServerLoginAddress");
 		ServerUsername = Config->GetValue("ServerUsername");
 		ServerPassword = Config->GetValue("ServerPassword");
+#endif
 	}
 
 	return true;

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -41,7 +41,7 @@
 #include "MatchupList.h"
 #include "Tools.h"
 
-#ifndef DISABLE_CURL
+#ifdef ENABLE_CURL
 #include "curl.h"
 #endif
 
@@ -861,10 +861,10 @@ bool LadderManager::LoadSetup()
 	std::string EnableReplayUploadString = Config->GetValue("EnableReplayUpload");
 	if (EnableReplayUploadString == "True")
 	{
-#ifdef DISABLE_CURL
+#ifndef ENABLE_CURL
 		throw std::logic_error(
-				"ERROR: Project was compiled with DISABLE_CURL but ladder manager is configured with EnableReplayUpload=True!"
-				" Either set EnableReplayUpload to False in the ladder configuration or run CMake with DISABLE_CURL set to OFF");
+				"ERROR: Project was compiled without ENABLE_CURL but ladder manager is configured with EnableReplayUpload=True!"
+				" Either set EnableReplayUpload to False in the ladder configuration or run CMake without ENABLE_CURL set to OFF");
 #else
         EnableReplayUploads = true;
 #endif
@@ -875,10 +875,10 @@ bool LadderManager::LoadSetup()
 	std::string EnableServerLoginString = Config->GetValue("EnableServerLogin");
 	if (EnableServerLoginString == "True")
 	{
-#ifdef DISABLE_CURL
+#ifndef ENABLE_CURL
 		throw std::logic_error(
-				"ERROR: Project was compiled with DISABLE_CURL but ladder manager is configured with EnableServerLogin=True!"
-				" Either set EnableServerLogin to False in the ladder configuration or run CMake with DISABLE_CURL set to OFF");
+				"ERROR: Project was compiled without ENABLE_CURL but ladder manager is configured with EnableServerLogin=True!"
+				" Either set EnableServerLogin to False in the ladder configuration or run CMake with ENABLE_CURL set to ON");
 #else
         EnableServerLogin = true;
 		ServerLoginAddress = Config->GetValue("ServerLoginAddress");
@@ -1071,7 +1071,7 @@ std::string LadderManager::RemoveMapExtension(const std::string& filename) {
 
 bool LadderManager::UploadMime(ResultType result, const Matchup &ThisMatch)
 {
-#ifdef DISABLE_CURL
+#ifndef ENABLE_CURL
 	return true;
 #else
 	std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
@@ -1167,7 +1167,7 @@ bool LadderManager::UploadMime(ResultType result, const Matchup &ThisMatch)
 
 bool LadderManager::LoginToServer()
 {
-#ifdef DISABLE_CURL
+#ifndef ENABLE_CURL
 	return true;
 #else
 	CURL *curl;

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -15,6 +15,7 @@
 #include "sc2api/sc2_client.h"
 #include "sc2api/sc2_proto_to_pods.h"
 #include "civetweb.h"
+#include <exception>
 
 #define RAPIDJSON_HAS_STDSTRING 1
 
@@ -860,7 +861,11 @@ bool LadderManager::LoadSetup()
 	std::string EnableReplayUploadString = Config->GetValue("EnableReplayUpload");
 	if (EnableReplayUploadString == "True")
 	{
-		EnableReplayUploads = true;
+	    #ifdef DISABLE_CURL
+	    throw std::logic_error("ERROR: Project was compiled with DISABLE_CURL but ladder manager is configured with EnableReplayUpload=True!");
+        #else
+        EnableReplayUploads = true;
+        #endif
 	}
 
 	ResultsLogFile = Config->GetValue("ResultsLogFile");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories(SYSTEM
 # Link directories
 link_directories(${PROJECT_BINARY_DIR}/s2client-api/bin)
 
-if (NOT DISABLE_CURL AND WIN32) # Curl library for windows
+if (ENABLE_CURL AND WIN32) # Curl library for windows
 	link_directories(${PROJECT_SOURCE_DIR}/curl/lib)
 endif ()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,8 +23,7 @@ include_directories(SYSTEM
 # Link directories
 link_directories(${PROJECT_BINARY_DIR}/s2client-api/bin)
 
-
-if (WIN32) # Curl library for windows
+if (NOT DISABLE_CURL AND WIN32) # Curl library for windows
 	link_directories(${PROJECT_SOURCE_DIR}/curl/lib)
 endif ()
 


### PR DESCRIPTION
- Provide the option to disable curl via setting the cmake option: DISABLE_CURL=ON.
- Avoid including the curl header when DISABLE_CURL is defined - not sure this is really needed, but it seemed cleaner.