### PR TITLE
UnixTools: Fix Python bots launch ##63

### DIFF
--- a/src/sc2laddercore/ToolsUnix.cpp
+++ b/src/sc2laddercore/ToolsUnix.cpp
@@ -55,7 +55,13 @@ void StartBotProcess(const BotConfig &Agent, const std::string &CommandLine, uns
 
         unix_cmd.push_back(NULL);
 
-        ret = execv(unix_cmd.front(), &unix_cmd.front());
+        // NOTE (alkurbatov): For the Python bots we need to search in the PATH
+        // for the interpreter.
+        if (Agent.Type == Python)
+            ret = execvp(unix_cmd.front(), &unix_cmd.front());
+        else
+            ret = execv(unix_cmd.front(), &unix_cmd.front());
+
         if (ret < 0)
         {
             std::cerr << Agent.BotName + ": Failed to execute '" + CommandLine +


### PR DESCRIPTION
The Python bots need the Python interpreter to run and we form
a commandline without absolute or relative path (.e.g. python
bots/bot/run.py). It doesn't work with the current implementation as
don't take PATH into account.

This commit uses execvp for the Python bots to fix the issue. For the
binary bots the old approach is preserved in order to avoid
path specifications for binary executables (e.g. ./Bot) otherwise we
have to add the executables to PATH which is not convenient.