### PR TITLE
Fix int test config on linux

### DIFF
--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,11 +1,17 @@
 # Test source files
 file(GLOB SOURCES_SC2LADDERSERVER_INTEGRATION_TESTS "*.cpp" "*.h")
 
+if (WIN32)
+	set(DEBUG_BOT_FILENAME "DebugBot.exe")
+else ()
+	set(DEBUG_BOT_FILENAME "DebugBot")
+endif ()
+
 # copy test data/configs
 configure_file(${CMAKE_CURRENT_LIST_DIR}/integration_test_configs/TestMatch_Bot1Eliminated/LadderBots.json
-    ${EXECUTABLE_OUTPUT_PATH}/integration_test_configs/TestMatch_Bot1Eliminated/LadderBots.json COPYONLY)
+    ${EXECUTABLE_OUTPUT_PATH}/integration_test_configs/TestMatch_Bot1Eliminated/LadderBots.json)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/integration_test_configs/TestMatch_Bot1Eliminated/LadderManager.json
-    ${EXECUTABLE_OUTPUT_PATH}/integration_test_configs/TestMatch_Bot1Eliminated/LadderManager.json COPYONLY)
+    ${EXECUTABLE_OUTPUT_PATH}/integration_test_configs/TestMatch_Bot1Eliminated/LadderManager.json)
 
 # Include directories
 include_directories(SYSTEM

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,13 +1,14 @@
 # Test source files
 file(GLOB SOURCES_SC2LADDERSERVER_INTEGRATION_TESTS "*.cpp" "*.h")
 
+# This variable is used in the test configs
 if (WIN32)
 	set(DEBUG_BOT_FILENAME "DebugBot.exe")
 else ()
 	set(DEBUG_BOT_FILENAME "DebugBot")
 endif ()
 
-# copy test data/configs
+# copy test data/configs and replace any variables they might contain
 configure_file(${CMAKE_CURRENT_LIST_DIR}/integration_test_configs/TestMatch_Bot1Eliminated/LadderBots.json
     ${EXECUTABLE_OUTPUT_PATH}/integration_test_configs/TestMatch_Bot1Eliminated/LadderBots.json)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/integration_test_configs/TestMatch_Bot1Eliminated/LadderManager.json

--- a/tests/integration/integration_test_configs/TestMatch_Bot1Eliminated/LadderBots.json
+++ b/tests/integration/integration_test_configs/TestMatch_Bot1Eliminated/LadderBots.json
@@ -5,13 +5,13 @@
       "Race": "Terran",
       "Type": "binarycpp",
       "RootPath": "./",
-      "FileName": "DebugBot"
+      "FileName": "@DEBUG_BOT_FILENAME@"
     },
     "DebugBot2": {
       "Race": "Terran",
       "Type": "binarycpp",
       "RootPath": "./",
-      "FileName": "DebugBot"
+      "FileName": "@DEBUG_BOT_FILENAME@"
     }
   },
   "Maps": [


### PR DESCRIPTION
This should resolve the ladder not being able to locate debug bot when running the integration tests on linux (as well as other non-Win32 platforms).