### PR TITLE
Use sc2::TerminateProcess to kill SC2 clients

### DIFF
--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -589,13 +589,13 @@ ResultType LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 	sc2::ProcessSettings process_settings;
 	sc2::GameSettings game_settings;
 	sc2::ParseSettings(CoordinatorArgc, CoordinatorArgv, process_settings, game_settings);
-	uint64_t Bot1ProcessId = sc2::StartProcess(process_settings.process_path,
+	uint64_t GameClientPid1 = sc2::StartProcess(process_settings.process_path,
 	{ "-listen", "127.0.0.1",
 		"-port", "5679",
 		"-displayMode", "0",
 		"-dataVersion", process_settings.data_version }
 	);
-	uint64_t Bot2ProcessId = sc2::StartProcess(process_settings.process_path,
+	uint64_t GameClientPid2 = sc2::StartProcess(process_settings.process_path,
 		{ "-listen", "127.0.0.1",
 		"-port", "5680",
 		"-displayMode", "0",
@@ -611,7 +611,7 @@ ResultType LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 		sc2::SleepFor(1000);
 		if (connectionAttemptsClient1 > 60)
 		{
-			PrintThread{} << "Failed to connect client 1. BotProcessID: " << Bot1ProcessId << std::endl;
+			PrintThread{} << "Failed to connect client 1. BotProcessID: " << GameClientPid1 << std::endl;
 			return ResultType::InitializationError;
 		}
 	}
@@ -623,7 +623,7 @@ ResultType LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 		sc2::SleepFor(1000);
 		if (connectionAttemptsClient2 > 60)
 		{
-			PrintThread{} << "Failed to connect client 2. BotProcessID: " << Bot2ProcessId << std::endl;
+			PrintThread{} << "Failed to connect client 2. BotProcessID: " << GameClientPid2 << std::endl;
 			return ResultType::InitializationError;
 		}
 	}
@@ -767,8 +767,8 @@ ResultType LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 	if (CurrentResult == Player1Crash || CurrentResult == Player2Crash)
 	{
 		sc2::SleepFor(5000);
-		KillSc2Process((unsigned long)Bot1ProcessId);
-		KillSc2Process((unsigned long)Bot2ProcessId);
+		sc2::TerminateProcess(GameClientPid1);
+		sc2::TerminateProcess(GameClientPid2);
 		sc2::SleepFor(5000);
 		try
 		{
@@ -798,12 +798,12 @@ ResultType LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 	if (bot1ProgStatus != std::future_status::ready)
 	{
 		PrintThread{} << "Failed to detect end of " << Agent1.BotName << " after 20s.  Killing" << std::endl;
-		KillSc2Process(Bot1ThreadId);
+		KillBotProcess(Bot1ThreadId);
 	}
 	if (bot2ProgStatus != std::future_status::ready)
 	{
 		PrintThread{} << "Failed to detect end of " << Agent2.BotName << " after 20s.  Killing" << std::endl;
-		KillSc2Process(Bot2ThreadId);
+		KillBotProcess(Bot2ThreadId);
 	}
 	return CurrentResult;
 }

--- a/src/sc2laddercore/Tools.h
+++ b/src/sc2laddercore/Tools.h
@@ -7,7 +7,7 @@ void StartBotProcess(const BotConfig &Agent, const std::string& CommandLine, uns
 
 void SleepFor(int seconds);
 
-void KillSc2Process(unsigned long pid);
+void KillBotProcess(unsigned long pid);
 
 bool MoveReplayFile(const char* lpExistingFileName, const char* lpNewFileName);
 

--- a/src/sc2laddercore/ToolsUnix.cpp
+++ b/src/sc2laddercore/ToolsUnix.cpp
@@ -131,7 +131,7 @@ void SleepFor(int seconds)
     sleep(seconds);
 }
 
-void KillSc2Process(unsigned long pid)
+void KillBotProcess(unsigned long pid)
 {
     int ret = kill(pid, SIGKILL);
     if (ret < 0)

--- a/src/sc2laddercore/ToolsWindows.cpp
+++ b/src/sc2laddercore/ToolsWindows.cpp
@@ -130,7 +130,7 @@ void SleepFor(int seconds)
 	Sleep(seconds * 1000);
 }
 
-void KillSc2Process(unsigned long pid)
+void KillBotProcess(unsigned long pid)
 {
 	DWORD dwDesiredAccess = PROCESS_TERMINATE;
 	BOOL  bInheritHandle = FALSE;


### PR DESCRIPTION
The API tracks all the spawned game processes when one calls sc2::StartProcess.
(seems that it is done to kill all the processes spawned by the game).
It is expected that the API's user will call sc2::TerminateProcess which will
kill all the childs and free remembered pids. Since we use our
own 'killSc2' implementation the pid is never freed and we have a kind
of memory leak.

Lets use sc2::TerminateProcess to avoid the leak.

Also some renaming done for better readability.