### PR TITLE
fix average step calculation

### DIFF
--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -100,7 +100,7 @@ float_t CalculateAverage(float_t OriginalValue, long NewValue, int32_t NumValues
 	{
 		return (float_t)NewValue;
 	}
-	return ((OriginalValue * NumValues) + NewValue) / (NumValues++);
+	return ((OriginalValue * NumValues) + NewValue) / (1 + NumValues);
 }
 
 


### PR DESCRIPTION
The formula for updating the average was incorrect, resulting in significantly inflated values, NumValues++ doesn't increment until after the value is used in the equation. As a result ++NumValues or NumValues + 1 should be used instead.