### PR TITLE
Make love not indentation war

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,10 @@
 root = true
 
-[*.{cc,h}]
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{cpp,h,json}]
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true


### PR DESCRIPTION
Resubmit without whole project auto-format, only:
- Update editorconfig

Edit: Tab characters in the README were intentionally left there.
Edit2: Removed "Replace tab characters with 4 spaces" commit