### PR TITLE
Change from average step time to average loop time

### DIFF
--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -115,6 +115,7 @@ ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server, const std::str
 	clock_t FirstRequest = clock();
 	clock_t StepTime = 0;
 	uint32_t currentGameLoop = 0;
+	float_t totalTime = 0;
 	float_t AvgStepTime = 0;
 	std::map<SC2APIProtocol::Status, std::string> status;
 	status[SC2APIProtocol::Status::launched] = "launched";
@@ -161,7 +162,8 @@ ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server, const std::str
 					else if (StepTime > 0 && request.second->has_step())
 					{
 						clock_t ThisStepTime = clock() - StepTime;
-						AvgStepTime = CalculateAverage(AvgStepTime, ThisStepTime, currentGameLoop);
+						totalTime += static_cast<float_t>(ThisStepTime);
+						AvgStepTime = totalTime/static_cast<float_t>(currentGameLoop);
 					}
 				}
 				if (client->connection_ != nullptr)

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -114,7 +114,7 @@ ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server, const std::str
 	clock_t LastRequest = clock();
 	clock_t FirstRequest = clock();
 	clock_t StepTime = 0;
-    uint32_t currentGameLoop = 0;
+	uint32_t currentGameLoop = 0;
 	float_t AvgStepTime = 0;
 	std::map<SC2APIProtocol::Status, std::string> status;
 	status[SC2APIProtocol::Status::launched] = "launched";

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -94,14 +94,6 @@ bool ProcessResponse(const SC2APIProtocol::ResponseCreateGame& response)
 
 }
 
-float_t CalculateAverage(float_t OriginalValue, long NewValue, int32_t NumValues)
-{
-	if (NumValues == 0 || OriginalValue == 0)
-	{
-		return (float_t)NewValue;
-	}
-	return ((OriginalValue * NumValues) + NewValue) / (1 + NumValues);
-}
 
 
 ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server, const std::string *botName, uint32_t MaxGameTime, uint32_t MaxRealGameTime, float_t *AvgFrame, int32_t *GameLoop)

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -114,7 +114,7 @@ ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server, const std::str
 	clock_t LastRequest = clock();
 	clock_t FirstRequest = clock();
 	clock_t StepTime = 0;
-	int32_t steps = 0;
+    uint32_t currentGameLoop = 0;
 	float_t AvgStepTime = 0;
 	std::map<SC2APIProtocol::Status, std::string> status;
 	status[SC2APIProtocol::Status::launched] = "launched";
@@ -161,8 +161,7 @@ ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server, const std::str
 					else if (StepTime > 0 && request.second->has_step())
 					{
 						clock_t ThisStepTime = clock() - StepTime;
-						AvgStepTime = CalculateAverage(AvgStepTime, ThisStepTime, steps);
-						steps++;
+						AvgStepTime = CalculateAverage(AvgStepTime, ThisStepTime, currentGameLoop);
 					}
 				}
 				if (client->connection_ != nullptr)
@@ -190,7 +189,7 @@ ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server, const std::str
 					{
 						const SC2APIProtocol::ResponseObservation LastObservation = response->observation();
 						const SC2APIProtocol::Observation& ActualObservation = LastObservation.observation();
-						uint32_t currentGameLoop = ActualObservation.game_loop();
+						currentGameLoop = ActualObservation.game_loop();
 						if (currentGameLoop > MaxGameTime)
 						{
 							CurrentExitCase = ExitCase::GameTimeout;


### PR DESCRIPTION
At the moment it calculates the average step time. With different step sizes unknown to everyone but the bot author it makes comparison difficult.

I changed it to average loop time.

Sorry for the commit mess. But I think you can accept pull request with rebase.