### PR TITLE
Fix for OnEnd issue

### DIFF
--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -847,8 +847,8 @@ GameResult LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 		CurrentResult = GetPlayerResults(&client2);
 	}
 	sc2::SleepFor(1000);
+	PrintThread{} << "Saving replay" << std::endl;
 	std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
-
 	std::string ReplayFile = ReplayDir + Agent1.BotName + "v" + Agent2.BotName + "-" + RemoveMapExtension(Map) + ".SC2Replay";
 	ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
 	if (!SaveReplay(&client, ReplayFile))
@@ -858,23 +858,24 @@ GameResult LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 	sc2::SleepFor(1000);
 	ChangeBotNames(ReplayFile, Agent1.BotName, Agent2.BotName);
 	// Process last requests
+	PrintThread{} << "Test1" << std::endl;
 	std::thread onEnd1(&OnEnd, &client, &server, &Agent1.BotName);
 	std::thread onEnd2(&OnEnd, &client2, &server2, &Agent2.BotName);
+	PrintThread{} << "Test2" << std::endl;
 	onEnd1.join();
 	onEnd2.join();
-	sc2::SleepFor(1000);
-	sc2::TerminateProcess(GameClientPid1);
-	sc2::TerminateProcess(GameClientPid2);
-	sc2::SleepFor(1000);
+	PrintThread{} << "Test3" << std::endl;
 	std::future_status bot1ProgStatus, bot2ProgStatus;
 	auto start = std::chrono::system_clock::now();
 	std::chrono::duration<double> elapsed_seconds;
+	PrintThread{} << "Are they ready?" << std::endl;
 	while (elapsed_seconds.count() < 20)
 	{
 		bot1ProgStatus = bot1ProgramThread.wait_for(50ms);
 		bot2ProgStatus = bot2ProgramThread.wait_for(50ms);
 		if (bot1ProgStatus == std::future_status::ready && bot2ProgStatus == std::future_status::ready)
 		{
+			PrintThread{} << "Ready!" << std::endl;
 			break;
 		}
 		elapsed_seconds = std::chrono::system_clock::now() - start;
@@ -889,6 +890,10 @@ GameResult LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 		PrintThread{} << "Failed to detect end of " << Agent2.BotName << " after 20s.  Killing" << std::endl;
 		KillBotProcess(Bot2ThreadId);
 	}
+	sc2::SleepFor(1000);
+	sc2::TerminateProcess(GameClientPid1);
+	sc2::TerminateProcess(GameClientPid2);
+	sc2::SleepFor(1000);
 	GameResult Result;
 	Result.Result = CurrentResult;
 	Result.Bot1AvgFrame = Bot1AvgFrame;

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -858,17 +858,13 @@ GameResult LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 	sc2::SleepFor(1000);
 	ChangeBotNames(ReplayFile, Agent1.BotName, Agent2.BotName);
 	// Process last requests
-	PrintThread{} << "Test1" << std::endl;
 	std::thread onEnd1(&OnEnd, &client, &server, &Agent1.BotName);
 	std::thread onEnd2(&OnEnd, &client2, &server2, &Agent2.BotName);
-	PrintThread{} << "Test2" << std::endl;
 	onEnd1.join();
 	onEnd2.join();
-	PrintThread{} << "Test3" << std::endl;
 	std::future_status bot1ProgStatus, bot2ProgStatus;
 	auto start = std::chrono::system_clock::now();
 	std::chrono::duration<double> elapsed_seconds;
-	PrintThread{} << "Are they ready?" << std::endl;
 	while (elapsed_seconds.count() < 20)
 	{
 		bot1ProgStatus = bot1ProgramThread.wait_for(50ms);
@@ -882,12 +878,12 @@ GameResult LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 	}
 	if (bot1ProgStatus != std::future_status::ready)
 	{
-		PrintThread{} << "Failed to detect end of " << Agent1.BotName << " after 20s.  Killing" << std::endl;
+		PrintThread{} << "Failed to detect end of " << Agent1.BotName << " after 20s. Make sure the bot does not issue leaveGame or quit. Killing" << std::endl;
 		KillBotProcess(Bot1ThreadId);
 	}
 	if (bot2ProgStatus != std::future_status::ready)
 	{
-		PrintThread{} << "Failed to detect end of " << Agent2.BotName << " after 20s.  Killing" << std::endl;
+		PrintThread{} << "Failed to detect end of " << Agent2.BotName << " after 20s. Make sure the bot does not issue leaveGame or quit. Killing" << std::endl;
 		KillBotProcess(Bot2ThreadId);
 	}
 	sc2::SleepFor(1000);

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -257,15 +257,6 @@ ExitCase OnEnd(sc2::Connection *client, sc2::Server *server, const std::string *
 	ExitCase CurrentExitCase = ExitCase::InProgress;
 	PrintThread{} << "Processing last requests/responses for " << *botName << std::endl;
 	std::time_t LastRequest = std::time(nullptr);
-	std::map<SC2APIProtocol::Status, std::string> status;
-	status[SC2APIProtocol::Status::launched] = "launched";
-	status[SC2APIProtocol::Status::init_game] = "init_game";
-	status[SC2APIProtocol::Status::in_game] = "in_game";
-	status[SC2APIProtocol::Status::in_replay] = "in_replay";
-	status[SC2APIProtocol::Status::ended] = "ended";
-	status[SC2APIProtocol::Status::quit] = "quit";
-	status[SC2APIProtocol::Status::unknown] = "unknown";
-	SC2APIProtocol::Status OldStatus = SC2APIProtocol::Status::in_game;
 	try
 	{
 		while (CurrentExitCase == ExitCase::InProgress)
@@ -722,7 +713,7 @@ GameResult LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 		sc2::SleepFor(1000);
 		if (connectionAttemptsClient1 > 60)
 		{
-			PrintThread{} << "Failed to connect client 1. BotProcessID: " << GameClientPid1 << std::endl;
+			PrintThread{} << "Failed to connect client 1. ClientProcessID: " << GameClientPid1 << std::endl;
 			return GameResult();
 		}
 	}
@@ -734,7 +725,7 @@ GameResult LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 		sc2::SleepFor(1000);
 		if (connectionAttemptsClient2 > 60)
 		{
-			PrintThread{} << "Failed to connect client 2. BotProcessID: " << GameClientPid2 << std::endl;
+			PrintThread{} << "Failed to connect client 2. ClientProcessID: " << GameClientPid2 << std::endl;
 			return GameResult();
 		}
 	}
@@ -862,6 +853,16 @@ GameResult LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 	std::thread onEnd2(&OnEnd, &client2, &server2, &Agent2.BotName);
 	onEnd1.join();
 	onEnd2.join();
+	sc2::SleepFor(1000);
+	if (!server.connections_.empty())
+	{
+		server.connections_.clear();
+		PrintThread{} << Agent1.BotName << " is still connected..."<< std::endl;
+	}
+	if (!server2.connections_.empty())
+	{
+		PrintThread{} << Agent2.BotName << " is still connected..." << std::endl;
+	}
 	std::future_status bot1ProgStatus, bot2ProgStatus;
 	auto start = std::chrono::system_clock::now();
 	std::chrono::duration<double> elapsed_seconds;

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -872,7 +872,7 @@ GameResult LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Ag
 		bot2ProgStatus = bot2ProgramThread.wait_for(50ms);
 		if (bot1ProgStatus == std::future_status::ready && bot2ProgStatus == std::future_status::ready)
 		{
-			PrintThread{} << "Ready!" << std::endl;
+			PrintThread{} << "Both bots quit properly." << std::endl;
 			break;
 		}
 		elapsed_seconds = std::chrono::system_clock::now() - start;
@@ -1358,7 +1358,7 @@ void LadderManager::RunLadderManager()
 			if (IsBotEnabled(NextMatch.Agent1.BotName) && IsBotEnabled(NextMatch.Agent2.BotName) && IsInsideEloRange(NextMatch.Agent1.BotName, NextMatch.Agent2.BotName))
 			{
 				GameResult result;
-				PrintThread{} << std::endl << "Starting " << NextMatch.Agent1.BotName << " vs " << NextMatch.Agent2.BotName << " on " << NextMatch.Map << std::endl;
+				PrintThread{} << "Starting " << NextMatch.Agent1.BotName << " vs " << NextMatch.Agent2.BotName << " on " << NextMatch.Map << std::endl;
 				if (NextMatch.Agent1.Type == DefaultBot || NextMatch.Agent2.Type == DefaultBot)
 				{
 					if (NextMatch.Agent1.Type == DefaultBot)
@@ -1374,7 +1374,7 @@ void LadderManager::RunLadderManager()
 				{
 					result = StartGame(NextMatch.Agent1, NextMatch.Agent2, NextMatch.Map);
 				}
-				PrintThread{} << std::endl << "Game finished with result: " << GetResultType(result.Result) << std::endl;
+				PrintThread{} << "Game finished with result: " << GetResultType(result.Result) << std::endl;
 				if (EnableReplayUploads)
 				{
 					UploadCmdLine(result, NextMatch);

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -45,52 +45,52 @@ std::mutex PrintThread::_mutexPrint{};
 
 bool ProcessResponse(const SC2APIProtocol::ResponseCreateGame& response)
 {
-    bool success = true;
-    if (response.has_error()) {
-        std::string errorCode = "Unknown";
-        switch (response.error()) {
-        case SC2APIProtocol::ResponseCreateGame::MissingMap: {
-            errorCode = "Missing Map";
-            break;
-        }
-        case SC2APIProtocol::ResponseCreateGame::InvalidMapPath: {
-            errorCode = "Invalid Map Path";
-            break;
-        }
-        case SC2APIProtocol::ResponseCreateGame::InvalidMapData: {
-            errorCode = "Invalid Map Data";
-            break;
-        }
-        case SC2APIProtocol::ResponseCreateGame::InvalidMapName: {
-            errorCode = "Invalid Map Name";
-            break;
-        }
-        case SC2APIProtocol::ResponseCreateGame::InvalidMapHandle: {
-            errorCode = "Invalid Map Handle";
-            break;
-        }
-        case SC2APIProtocol::ResponseCreateGame::MissingPlayerSetup: {
-            errorCode = "Missing Player Setup";
-            break;
-        }
-        case SC2APIProtocol::ResponseCreateGame::InvalidPlayerSetup: {
-            errorCode = "Invalid Player Setup";
-            break;
-        }
-        default: {
-            break;
-        }
-        }
+	bool success = true;
+	if (response.has_error()) {
+		std::string errorCode = "Unknown";
+		switch (response.error()) {
+		case SC2APIProtocol::ResponseCreateGame::MissingMap: {
+			errorCode = "Missing Map";
+			break;
+		}
+		case SC2APIProtocol::ResponseCreateGame::InvalidMapPath: {
+			errorCode = "Invalid Map Path";
+			break;
+		}
+		case SC2APIProtocol::ResponseCreateGame::InvalidMapData: {
+			errorCode = "Invalid Map Data";
+			break;
+		}
+		case SC2APIProtocol::ResponseCreateGame::InvalidMapName: {
+			errorCode = "Invalid Map Name";
+			break;
+		}
+		case SC2APIProtocol::ResponseCreateGame::InvalidMapHandle: {
+			errorCode = "Invalid Map Handle";
+			break;
+		}
+		case SC2APIProtocol::ResponseCreateGame::MissingPlayerSetup: {
+			errorCode = "Missing Player Setup";
+			break;
+		}
+		case SC2APIProtocol::ResponseCreateGame::InvalidPlayerSetup: {
+			errorCode = "Invalid Player Setup";
+			break;
+		}
+		default: {
+			break;
+		}
+		}
 
-        std::cerr << "CreateGame request returned an error code: " << errorCode << std::endl;
-        success = false;
-    }
+		std::cerr << "CreateGame request returned an error code: " << errorCode << std::endl;
+		success = false;
+	}
 
-    if (response.has_error_details() && response.error_details().length() > 0) {
-        std::cerr << "CreateGame request returned error details: " << response.error_details() << std::endl;
-        success = false;
-    }
-    return success;
+	if (response.has_error_details() && response.error_details().length() > 0) {
+		std::cerr << "CreateGame request returned error details: " << response.error_details() << std::endl;
+		success = false;
+	}
+	return success;
 
 }
 
@@ -99,1351 +99,1351 @@ bool gameEnded = false;
 
 void setGameEnded(const bool status)
 {
-    std::lock_guard<std::mutex> lock(m);
-    gameEnded = status;
+	std::lock_guard<std::mutex> lock(m);
+	gameEnded = status;
 }
 
 bool getGameEnded()
 {
-    std::lock_guard<std::mutex> lock(m);
-    return gameEnded;
+	std::lock_guard<std::mutex> lock(m);
+	return gameEnded;
 }
 
 ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server, const std::string *botName, uint32_t MaxGameTime, uint32_t MaxRealGameTime, float_t *AvgFrame, int32_t *GameLoop)
 {
-    ExitCase CurrentExitCase = ExitCase::InProgress;
-    PrintThread{} << "Starting proxy for " << *botName << std::endl;
-    setGameEnded(false);
-    clock_t LastRequest = clock();
-    clock_t FirstRequest = clock();
-    clock_t StepTime = 0;
-    uint32_t currentGameLoop = 0;
-    float_t totalTime = 0;
-    float_t AvgStepTime = 0;
-    std::map<SC2APIProtocol::Status, std::string> status;
-    status[SC2APIProtocol::Status::launched] = "launched";
-    status[SC2APIProtocol::Status::init_game] = "init_game";
-    status[SC2APIProtocol::Status::in_game] = "in_game";
-    status[SC2APIProtocol::Status::in_replay] = "in_replay";
-    status[SC2APIProtocol::Status::ended] = "ended";
-    status[SC2APIProtocol::Status::quit] = "quit";
-    status[SC2APIProtocol::Status::unknown] = "unknown";
-    SC2APIProtocol::Status OldStatus = SC2APIProtocol::Status::unknown;
-    try
-    {
-        bool RequestFound = false;
-        bool AlreadyWarned = false;
-        while (CurrentExitCase == ExitCase::InProgress && !getGameEnded()) {
-            SC2APIProtocol::Status CurrentStatus;
-            if (!client || !server)
-            {
-                PrintThread{} << botName << " Null server or client returning ClientTimeout" << std::endl;
-                return ExitCase::ClientTimeout;
-            }
-            if (client->connection_ == nullptr && RequestFound)
-            {
-                PrintThread{} << "Client disconnect (" << *botName << ")" << std::endl;
-                CurrentExitCase = ExitCase::ClientTimeout;
-            }
+	ExitCase CurrentExitCase = ExitCase::InProgress;
+	PrintThread{} << "Starting proxy for " << *botName << std::endl;
+	setGameEnded(false);
+	clock_t LastRequest = clock();
+	clock_t FirstRequest = clock();
+	clock_t StepTime = 0;
+	uint32_t currentGameLoop = 0;
+	float_t totalTime = 0;
+	float_t AvgStepTime = 0;
+	std::map<SC2APIProtocol::Status, std::string> status;
+	status[SC2APIProtocol::Status::launched] = "launched";
+	status[SC2APIProtocol::Status::init_game] = "init_game";
+	status[SC2APIProtocol::Status::in_game] = "in_game";
+	status[SC2APIProtocol::Status::in_replay] = "in_replay";
+	status[SC2APIProtocol::Status::ended] = "ended";
+	status[SC2APIProtocol::Status::quit] = "quit";
+	status[SC2APIProtocol::Status::unknown] = "unknown";
+	SC2APIProtocol::Status OldStatus = SC2APIProtocol::Status::unknown;
+	try
+	{
+		bool RequestFound = false;
+		bool AlreadyWarned = false;
+		while (CurrentExitCase == ExitCase::InProgress && !getGameEnded()) {
+			SC2APIProtocol::Status CurrentStatus;
+			if (!client || !server)
+			{
+				PrintThread{} << botName << " Null server or client returning ClientTimeout" << std::endl;
+				return ExitCase::ClientTimeout;
+			}
+			if (client->connection_ == nullptr && RequestFound)
+			{
+				PrintThread{} << "Client disconnect (" << *botName << ")" << std::endl;
+				CurrentExitCase = ExitCase::ClientTimeout;
+			}
 
-            if (server->HasRequest())
-            {
-                const sc2::RequestData request = server->PeekRequest();
-                if (request.second)
-                {
-                    if (request.second->has_quit()) //Really paranoid here...
-                    {
-                        // Intercept leave game and quit requests, we want to keep game alive to save replays
-                        CurrentExitCase = ExitCase::ClientRequestExit;
-                        break;
-                    }
-                    else if (request.second->has_debug() && !AlreadyWarned)
-                    {
-                        PrintThread{} << *botName << " IS USING DEBUG INTERFACE.  POSSIBLE CHEAT Please tell them not to" << std::endl;
-                        AlreadyWarned = true;
-                    }
-                    else if (StepTime > 0 && request.second->has_step())
-                    {
-                        clock_t ThisStepTime = clock() - StepTime;
-                        totalTime += static_cast<float_t>(ThisStepTime);
-                        AvgStepTime = totalTime/static_cast<float_t>(currentGameLoop);
-                    }
-                }
-                if (client->connection_ != nullptr)
-                {
-                    server->SendRequest(client->connection_);
+			if (server->HasRequest())
+			{
+				const sc2::RequestData request = server->PeekRequest();
+				if (request.second)
+				{
+					if (request.second->has_quit()) //Really paranoid here...
+					{
+						// Intercept leave game and quit requests, we want to keep game alive to save replays
+						CurrentExitCase = ExitCase::ClientRequestExit;
+						break;
+					}
+					else if (request.second->has_debug() && !AlreadyWarned)
+					{
+						PrintThread{} << *botName << " IS USING DEBUG INTERFACE.  POSSIBLE CHEAT Please tell them not to" << std::endl;
+						AlreadyWarned = true;
+					}
+					else if (StepTime > 0 && request.second->has_step())
+					{
+						clock_t ThisStepTime = clock() - StepTime;
+						totalTime += static_cast<float_t>(ThisStepTime);
+						AvgStepTime = totalTime/static_cast<float_t>(currentGameLoop);
+					}
+				}
+				if (client->connection_ != nullptr)
+				{
+					server->SendRequest(client->connection_);
 
-                }
+				}
 
-                // Block for sc2's response then queue it.
-                SC2APIProtocol::Response* response = nullptr;
-                client->Receive(response, 100000);
-                if (response != nullptr)
-                {
-                    CurrentStatus = response->status();
-                    if (OldStatus != CurrentStatus)
-                    {
-                        PrintThread{} << "New status of " << *botName << ": " << status.at(CurrentStatus) << std::endl;
-                        OldStatus = CurrentStatus;
-                    }
-                    if (CurrentStatus > SC2APIProtocol::Status::in_replay)
-                    {
-                        CurrentExitCase = ExitCase::GameEnd;
-                    }
-                    if (response->has_observation())
-                    {
-                        const SC2APIProtocol::ResponseObservation LastObservation = response->observation();
-                        const SC2APIProtocol::Observation& ActualObservation = LastObservation.observation();
-                        currentGameLoop = ActualObservation.game_loop();
-                        if (currentGameLoop > MaxGameTime)
-                        {
-                            CurrentExitCase = ExitCase::GameTimeout;
-                        }
-                        if (GameLoop != nullptr)
-                        {
-                            *GameLoop = currentGameLoop;
-                        }
-                    }
-                    else if (response->has_step())
-                    {
-                        StepTime = clock();
-                    }
-                    if (MaxRealGameTime > 0)
-                    {
-                        if (clock() > (FirstRequest + (MaxRealGameTime * CLOCKS_PER_SEC)))
-                        {
-                            CurrentExitCase = ExitCase::GameTimeout;
-                        }
-                    }
+				// Block for sc2's response then queue it.
+				SC2APIProtocol::Response* response = nullptr;
+				client->Receive(response, 100000);
+				if (response != nullptr)
+				{
+					CurrentStatus = response->status();
+					if (OldStatus != CurrentStatus)
+					{
+						PrintThread{} << "New status of " << *botName << ": " << status.at(CurrentStatus) << std::endl;
+						OldStatus = CurrentStatus;
+					}
+					if (CurrentStatus > SC2APIProtocol::Status::in_replay)
+					{
+						CurrentExitCase = ExitCase::GameEnd;
+					}
+					if (response->has_observation())
+					{
+						const SC2APIProtocol::ResponseObservation LastObservation = response->observation();
+						const SC2APIProtocol::Observation& ActualObservation = LastObservation.observation();
+						currentGameLoop = ActualObservation.game_loop();
+						if (currentGameLoop > MaxGameTime)
+						{
+							CurrentExitCase = ExitCase::GameTimeout;
+						}
+						if (GameLoop != nullptr)
+						{
+							*GameLoop = currentGameLoop;
+						}
+					}
+					else if (response->has_step())
+					{
+						StepTime = clock();
+					}
+					if (MaxRealGameTime > 0)
+					{
+						if (clock() > (FirstRequest + (MaxRealGameTime * CLOCKS_PER_SEC)))
+						{
+							CurrentExitCase = ExitCase::GameTimeout;
+						}
+					}
 
-                }
+				}
 
-                // Send the response back to the client.
-                if (server->connections_.size() > 0 && client->connection_ != NULL)
-                {
-                    server->QueueResponse(client->connection_, response);
-                    server->SendResponse();
-                }
-                else
-                {
-                    CurrentExitCase = ExitCase::ClientTimeout;
-                }
-                LastRequest = clock();
+				// Send the response back to the client.
+				if (server->connections_.size() > 0 && client->connection_ != NULL)
+				{
+					server->QueueResponse(client->connection_, response);
+					server->SendResponse();
+				}
+				else
+				{
+					CurrentExitCase = ExitCase::ClientTimeout;
+				}
+				LastRequest = clock();
 
-            }
-            else
-            {
-                if ((LastRequest + (50 * CLOCKS_PER_SEC)) < clock())
-                {
-                    PrintThread{} << "Client timeout (" << *botName <<")" << std::endl;
-                    CurrentExitCase = ExitCase::ClientTimeout;
-                }
-            }
-        }
-        *AvgFrame = AvgStepTime;
-        PrintThread{} << *botName << " Exiting with " << GetExitCaseString(CurrentExitCase) << " Average step time " << AvgStepTime << ", total time: " << totalTime << ", game loops: " << currentGameLoop << std::endl;
-        setGameEnded(true);
-        return CurrentExitCase;
-    }
-    catch (const std::exception& e)
-    {
-        PrintThread{} << e.what() << std::endl;
-        return ExitCase::ClientTimeout;
-    }
+			}
+			else
+			{
+				if ((LastRequest + (50 * CLOCKS_PER_SEC)) < clock())
+				{
+					PrintThread{} << "Client timeout (" << *botName <<")" << std::endl;
+					CurrentExitCase = ExitCase::ClientTimeout;
+				}
+			}
+		}
+		*AvgFrame = AvgStepTime;
+		PrintThread{} << *botName << " Exiting with " << GetExitCaseString(CurrentExitCase) << " Average step time " << AvgStepTime << ", total time: " << totalTime << ", game loops: " << currentGameLoop << std::endl;
+		setGameEnded(true);
+		return CurrentExitCase;
+	}
+	catch (const std::exception& e)
+	{
+		PrintThread{} << e.what() << std::endl;
+		return ExitCase::ClientTimeout;
+	}
 }
 
 ExitCase OnEnd(sc2::Connection *client, sc2::Server *server, const std::string *botName)
 {
-    ExitCase CurrentExitCase = ExitCase::InProgress;
-    PrintThread{} << "Processing last requests/responses for " << *botName << std::endl;
-    std::time_t LastRequest = std::time(nullptr);
-    std::map<SC2APIProtocol::Status, std::string> status;
-    status[SC2APIProtocol::Status::launched] = "launched";
-    status[SC2APIProtocol::Status::init_game] = "init_game";
-    status[SC2APIProtocol::Status::in_game] = "in_game";
-    status[SC2APIProtocol::Status::in_replay] = "in_replay";
-    status[SC2APIProtocol::Status::ended] = "ended";
-    status[SC2APIProtocol::Status::quit] = "quit";
-    status[SC2APIProtocol::Status::unknown] = "unknown";
-    SC2APIProtocol::Status OldStatus = SC2APIProtocol::Status::in_game;
-    try
-    {
-        while (CurrentExitCase == ExitCase::InProgress)
-        {
-            SC2APIProtocol::Status CurrentStatus;
-            if (!client || !server)
-            {
-                PrintThread{} << *botName << " Null server or client returning ClientTimeout" << std::endl;
-                return ExitCase::ClientTimeout;
-            }
-            if (client->connection_ == nullptr)
-            {
-                PrintThread{} << "Client disconnect (" << *botName << ")" << std::endl;
-                CurrentExitCase = ExitCase::ClientTimeout;
-            }
-            if (server->HasRequest())
-            {
-                if (client->connection_ != nullptr)
-                {
-                    PrintThread{} << "Sending request of " << *botName << std::endl;
-                    server->SendRequest(client->connection_);
-                    LastRequest = std::time(nullptr);
-                }
-            }
-            SC2APIProtocol::Response* response = nullptr;
-            if (client->Receive(response, 1000)) // why is server->hasResponse() not working?!
-            {
-                // Send the response back to the client.
-                if (response && server->connections_.size() > 0 && client->connection_ != NULL)
-                {
-                    PrintThread{} << "Sending response for " << *botName << std::endl;
-                    server->QueueResponse(client->connection_, response);
-                    server->SendResponse();
-                    LastRequest = std::time(nullptr);
-                }
-                else
-                {
-                    CurrentExitCase = ExitCase::ClientTimeout;
-                }
-            }
-            if (difftime(std::time(nullptr),LastRequest) > 5)
-            {
-                PrintThread{} << "No new requests/responses for (" << *botName <<")" << std::endl;
-                CurrentExitCase = ExitCase::ClientTimeout;
-            }
-        }
-        return CurrentExitCase;
-    }
-    catch (const std::exception& e)
-    {
-        PrintThread{} << e.what() << std::endl;
-        return ExitCase::ClientTimeout;
-    }
+	ExitCase CurrentExitCase = ExitCase::InProgress;
+	PrintThread{} << "Processing last requests/responses for " << *botName << std::endl;
+	std::time_t LastRequest = std::time(nullptr);
+	std::map<SC2APIProtocol::Status, std::string> status;
+	status[SC2APIProtocol::Status::launched] = "launched";
+	status[SC2APIProtocol::Status::init_game] = "init_game";
+	status[SC2APIProtocol::Status::in_game] = "in_game";
+	status[SC2APIProtocol::Status::in_replay] = "in_replay";
+	status[SC2APIProtocol::Status::ended] = "ended";
+	status[SC2APIProtocol::Status::quit] = "quit";
+	status[SC2APIProtocol::Status::unknown] = "unknown";
+	SC2APIProtocol::Status OldStatus = SC2APIProtocol::Status::in_game;
+	try
+	{
+		while (CurrentExitCase == ExitCase::InProgress)
+		{
+			SC2APIProtocol::Status CurrentStatus;
+			if (!client || !server)
+			{
+				PrintThread{} << *botName << " Null server or client returning ClientTimeout" << std::endl;
+				return ExitCase::ClientTimeout;
+			}
+			if (client->connection_ == nullptr)
+			{
+				PrintThread{} << "Client disconnect (" << *botName << ")" << std::endl;
+				CurrentExitCase = ExitCase::ClientTimeout;
+			}
+			if (server->HasRequest())
+			{
+				if (client->connection_ != nullptr)
+				{
+					PrintThread{} << "Sending request of " << *botName << std::endl;
+					server->SendRequest(client->connection_);
+					LastRequest = std::time(nullptr);
+				}
+			}
+			SC2APIProtocol::Response* response = nullptr;
+			if (client->Receive(response, 1000)) // why is server->hasResponse() not working?!
+			{
+				// Send the response back to the client.
+				if (response && server->connections_.size() > 0 && client->connection_ != NULL)
+				{
+					PrintThread{} << "Sending response for " << *botName << std::endl;
+					server->QueueResponse(client->connection_, response);
+					server->SendResponse();
+					LastRequest = std::time(nullptr);
+				}
+				else
+				{
+					CurrentExitCase = ExitCase::ClientTimeout;
+				}
+			}
+			if (difftime(std::time(nullptr),LastRequest) > 5)
+			{
+				PrintThread{} << "No new requests/responses for (" << *botName <<")" << std::endl;
+				CurrentExitCase = ExitCase::ClientTimeout;
+			}
+		}
+		return CurrentExitCase;
+	}
+	catch (const std::exception& e)
+	{
+		PrintThread{} << e.what() << std::endl;
+		return ExitCase::ClientTimeout;
+	}
 }
 
 bool LadderManager::SaveReplay(sc2::Connection *client, const std::string& path) {
-    sc2::ProtoInterface proto;
-    sc2::GameRequestPtr request = proto.MakeRequest();
-    request->mutable_save_replay();
-    SendDataToConnection(client, request.get());
-    SC2APIProtocol::Response* replay_response = nullptr;
-    if (!client->Receive(replay_response, 10000))
-    {
-        //		std::cout << "Failed to receive replay response" << std::endl;
-        return false;
-    }
+	sc2::ProtoInterface proto;
+	sc2::GameRequestPtr request = proto.MakeRequest();
+	request->mutable_save_replay();
+	SendDataToConnection(client, request.get());
+	SC2APIProtocol::Response* replay_response = nullptr;
+	if (!client->Receive(replay_response, 10000))
+	{
+		//		std::cout << "Failed to receive replay response" << std::endl;
+		return false;
+	}
 
-    const SC2APIProtocol::ResponseSaveReplay& response_replay = replay_response->save_replay();
+	const SC2APIProtocol::ResponseSaveReplay& response_replay = replay_response->save_replay();
 
-    if (response_replay.data().size() == 0) {
-        return false;
-    }
+	if (response_replay.data().size() == 0) {
+		return false;
+	}
 
-    std::ofstream file;
-    file.open(path, std::fstream::binary);
-    if (!file.is_open()) {
-        return false;
-    }
+	std::ofstream file;
+	file.open(path, std::fstream::binary);
+	if (!file.is_open()) {
+		return false;
+	}
 
-    file.write(&response_replay.data()[0], response_replay.data().size());
-    return true;
+	file.write(&response_replay.data()[0], response_replay.data().size());
+	return true;
 }
 
 bool LadderManager::ProcessObservationResponse(SC2APIProtocol::ResponseObservation Response, std::vector<sc2::PlayerResult> *PlayerResults)
 {
-    if (Response.player_result_size())
-    {
-        PlayerResults->clear();
-        for (const auto& player_result : Response.player_result()) {
-            PlayerResults->push_back(sc2::PlayerResult(player_result.player_id(), sc2::ConvertGameResultFromProto(player_result.result())));
-        }
-        return true;
-    }
-    return false;
+	if (Response.player_result_size())
+	{
+		PlayerResults->clear();
+		for (const auto& player_result : Response.player_result()) {
+			PlayerResults->push_back(sc2::PlayerResult(player_result.player_id(), sc2::ConvertGameResultFromProto(player_result.result())));
+		}
+		return true;
+	}
+	return false;
 }
 
 std::string LadderManager::GetBotCommandLine(const BotConfig &AgentConfig, int GamePort, int StartPort, const std::string &OpponentId, bool CompOpp, sc2::Race CompRace, sc2::Difficulty CompDifficulty)
 {
-    // Add bot type specific command line needs
-    std::string OutCmdLine;
-    switch (AgentConfig.Type)
-    {
-    case Python:
-    {
-        OutCmdLine = Config->GetValue("PythonBinary") + " " + AgentConfig.FileName;
-        break;
-    }
-    case Wine:
-    {
-        OutCmdLine = "wine " + AgentConfig.FileName;
-        break;
-    }
-    case Mono:
-    {
-        OutCmdLine = "mono " + AgentConfig.FileName;
-        break;
-    }
-    case DotNetCore:
-    {
-        OutCmdLine = "dotnet " + AgentConfig.FileName;
-        break;
-    }
-    case CommandCenter:
-    {
-        OutCmdLine = Config->GetValue("CommandCenterPath") + " --ConfigFile " + AgentConfig.FileName;
-        break;
-    }
-    case BinaryCpp:
-    {
-        OutCmdLine = AgentConfig.RootPath + AgentConfig.FileName;
-        break;
-    }
-    case Java:
-    {
-        OutCmdLine = "java -jar " + AgentConfig.FileName;
-        break;
-    }
-    case DefaultBot: {} // BlizzardAI - doesn't need any command line arguments
-    }
+	// Add bot type specific command line needs
+	std::string OutCmdLine;
+	switch (AgentConfig.Type)
+	{
+	case Python:
+	{
+		OutCmdLine = Config->GetValue("PythonBinary") + " " + AgentConfig.FileName;
+		break;
+	}
+	case Wine:
+	{
+		OutCmdLine = "wine " + AgentConfig.FileName;
+		break;
+	}
+	case Mono:
+	{
+		OutCmdLine = "mono " + AgentConfig.FileName;
+		break;
+	}
+	case DotNetCore:
+	{
+		OutCmdLine = "dotnet " + AgentConfig.FileName;
+		break;
+	}
+	case CommandCenter:
+	{
+		OutCmdLine = Config->GetValue("CommandCenterPath") + " --ConfigFile " + AgentConfig.FileName;
+		break;
+	}
+	case BinaryCpp:
+	{
+		OutCmdLine = AgentConfig.RootPath + AgentConfig.FileName;
+		break;
+	}
+	case Java:
+	{
+		OutCmdLine = "java -jar " + AgentConfig.FileName;
+		break;
+	}
+	case DefaultBot: {} // BlizzardAI - doesn't need any command line arguments
+	}
 
-    // Add universal arguments
-    OutCmdLine += " --GamePort " + std::to_string(GamePort) + " --StartPort " + std::to_string(StartPort) + " --LadderServer 127.0.0.1 --OpponentId " + OpponentId;
+	// Add universal arguments
+	OutCmdLine += " --GamePort " + std::to_string(GamePort) + " --StartPort " + std::to_string(StartPort) + " --LadderServer 127.0.0.1 --OpponentId " + OpponentId;
 
-    if (CompOpp)
-    {
-        OutCmdLine += " --ComputerOpponent 1 --ComputerRace " + GetRaceString(CompRace) + " --ComputerDifficulty " + GetDifficultyString(CompDifficulty);
-    }
-    if (AgentConfig.Args != "")
-    {
-        OutCmdLine += " " + AgentConfig.Args;
-    }
-    return OutCmdLine;
+	if (CompOpp)
+	{
+		OutCmdLine += " --ComputerOpponent 1 --ComputerRace " + GetRaceString(CompRace) + " --ComputerDifficulty " + GetDifficultyString(CompDifficulty);
+	}
+	if (AgentConfig.Args != "")
+	{
+		OutCmdLine += " " + AgentConfig.Args;
+	}
+	return OutCmdLine;
 }
 
 
 void ResolveMap(const std::string& map_name, SC2APIProtocol::RequestCreateGame* request, sc2::ProcessSettings process_settings) {
-    // BattleNet map
-    if (!sc2::HasExtension(map_name, ".SC2Map")) {
-        request->set_battlenet_map_name(map_name);
-        return;
-    }
+	// BattleNet map
+	if (!sc2::HasExtension(map_name, ".SC2Map")) {
+		request->set_battlenet_map_name(map_name);
+		return;
+	}
 
-    // Absolute path
-    SC2APIProtocol::LocalMap* local_map = request->mutable_local_map();
-    if (sc2::DoesFileExist(map_name)) {
-        local_map->set_map_path(map_name);
-        return;
-    }
+	// Absolute path
+	SC2APIProtocol::LocalMap* local_map = request->mutable_local_map();
+	if (sc2::DoesFileExist(map_name)) {
+		local_map->set_map_path(map_name);
+		return;
+	}
 
-    // Relative path - Game maps directory
-    std::string game_relative = sc2::GetGameMapsDirectory(process_settings.process_path) + map_name;
-    if (sc2::DoesFileExist(game_relative)) {
-        local_map->set_map_path(map_name);
-        return;
-    }
+	// Relative path - Game maps directory
+	std::string game_relative = sc2::GetGameMapsDirectory(process_settings.process_path) + map_name;
+	if (sc2::DoesFileExist(game_relative)) {
+		local_map->set_map_path(map_name);
+		return;
+	}
 
-    // Relative path - Library maps directory
-    std::string library_relative = sc2::GetLibraryMapsDirectory() + map_name;
-    if (sc2::DoesFileExist(library_relative)) {
-        local_map->set_map_path(library_relative);
-        return;
-    }
+	// Relative path - Library maps directory
+	std::string library_relative = sc2::GetLibraryMapsDirectory() + map_name;
+	if (sc2::DoesFileExist(library_relative)) {
+		local_map->set_map_path(library_relative);
+		return;
+	}
 
-    // Relative path - Remotely saved maps directory
-    local_map->set_map_path(map_name);
+	// Relative path - Remotely saved maps directory
+	local_map->set_map_path(map_name);
 }
 
 sc2::GameRequestPtr CreateStartGameRequest(const std::string &MapName, std::vector<sc2::PlayerSetup> players, sc2::ProcessSettings process_settings)
 {
-    sc2::ProtoInterface proto;
-    sc2::GameRequestPtr request = proto.MakeRequest();
+	sc2::ProtoInterface proto;
+	sc2::GameRequestPtr request = proto.MakeRequest();
 
-    SC2APIProtocol::RequestCreateGame* request_create_game = request->mutable_create_game();
-    for (const sc2::PlayerSetup& setup : players)
-    {
-        SC2APIProtocol::PlayerSetup* playerSetup = request_create_game->add_player_setup();
-        playerSetup->set_type(SC2APIProtocol::PlayerType(setup.type));
-        playerSetup->set_race(SC2APIProtocol::Race(int(setup.race) + 1));
-        playerSetup->set_difficulty(SC2APIProtocol::Difficulty(setup.difficulty));
-    }
-    ResolveMap(MapName, request_create_game, process_settings);
+	SC2APIProtocol::RequestCreateGame* request_create_game = request->mutable_create_game();
+	for (const sc2::PlayerSetup& setup : players)
+	{
+		SC2APIProtocol::PlayerSetup* playerSetup = request_create_game->add_player_setup();
+		playerSetup->set_type(SC2APIProtocol::PlayerType(setup.type));
+		playerSetup->set_race(SC2APIProtocol::Race(int(setup.race) + 1));
+		playerSetup->set_difficulty(SC2APIProtocol::Difficulty(setup.difficulty));
+	}
+	ResolveMap(MapName, request_create_game, process_settings);
 
-    request_create_game->set_realtime(false);
-    return request;
+	request_create_game->set_realtime(false);
+	return request;
 }
 
 sc2::GameResponsePtr LadderManager::CreateErrorResponse()
 {
-    const sc2::GameResponsePtr response = std::make_shared<SC2APIProtocol::Response>(SC2APIProtocol::Response());
-    return response;
+	const sc2::GameResponsePtr response = std::make_shared<SC2APIProtocol::Response>(SC2APIProtocol::Response());
+	return response;
 }
 
 sc2::GameRequestPtr LadderManager::CreateLeaveGameRequest()
 {
-    sc2::ProtoInterface proto;
-    sc2::GameRequestPtr request = proto.MakeRequest();
+	sc2::ProtoInterface proto;
+	sc2::GameRequestPtr request = proto.MakeRequest();
 
-    request->mutable_leave_game();
+	request->mutable_leave_game();
 
-    return request;
+	return request;
 }
 
 sc2::GameRequestPtr LadderManager::CreateQuitRequest()
 {
-    sc2::ProtoInterface proto;
-    sc2::GameRequestPtr request = proto.MakeRequest();
-    request->mutable_quit();
+	sc2::ProtoInterface proto;
+	sc2::GameRequestPtr request = proto.MakeRequest();
+	request->mutable_quit();
 
-    return request;
+	return request;
 }
 
 ResultType LadderManager::GetPlayerResults(sc2::Connection *client)
 {
-    if (client == nullptr)
-    {
-        return ResultType::ProcessingReplay;
-    }
-    sc2::ProtoInterface proto;
-    sc2::GameRequestPtr ObservationRequest = proto.MakeRequest();
-    ObservationRequest->mutable_observation();
-    SendDataToConnection(client, ObservationRequest.get());
+	if (client == nullptr)
+	{
+		return ResultType::ProcessingReplay;
+	}
+	sc2::ProtoInterface proto;
+	sc2::GameRequestPtr ObservationRequest = proto.MakeRequest();
+	ObservationRequest->mutable_observation();
+	SendDataToConnection(client, ObservationRequest.get());
 
-    SC2APIProtocol::Response* ObservationResponse = nullptr;
-    std::vector<sc2::PlayerResult> PlayerResults;
-    if (client->Receive(ObservationResponse, 100000))
-    {
-        ProcessObservationResponse(ObservationResponse->observation(), &PlayerResults);
-    }
-    if (PlayerResults.size() > 1)
-    {
-        if (PlayerResults.back().result == sc2::GameResult::Undecided)
-        {
-            return ResultType::ProcessingReplay;
-        }
-        else if (PlayerResults.back().result == sc2::GameResult::Tie)
-        {
-            return ResultType::Tie;
-        }
-        else if (PlayerResults.back().result == sc2::GameResult::Win)
-        {
-            if (PlayerResults.back().player_id == 1)
-            {
-                return ResultType::Player1Win;
-            }
-            else
-            {
-                return ResultType::Player2Win;
-            }
-        }
-        else if (PlayerResults.back().result == sc2::GameResult::Loss)
-        {
-            if (PlayerResults.back().player_id == 1)
-            {
-                return ResultType::Player2Win;
-            }
-            else
-            {
-                return ResultType::Player1Win;
-            }
+	SC2APIProtocol::Response* ObservationResponse = nullptr;
+	std::vector<sc2::PlayerResult> PlayerResults;
+	if (client->Receive(ObservationResponse, 100000))
+	{
+		ProcessObservationResponse(ObservationResponse->observation(), &PlayerResults);
+	}
+	if (PlayerResults.size() > 1)
+	{
+		if (PlayerResults.back().result == sc2::GameResult::Undecided)
+		{
+			return ResultType::ProcessingReplay;
+		}
+		else if (PlayerResults.back().result == sc2::GameResult::Tie)
+		{
+			return ResultType::Tie;
+		}
+		else if (PlayerResults.back().result == sc2::GameResult::Win)
+		{
+			if (PlayerResults.back().player_id == 1)
+			{
+				return ResultType::Player1Win;
+			}
+			else
+			{
+				return ResultType::Player2Win;
+			}
+		}
+		else if (PlayerResults.back().result == sc2::GameResult::Loss)
+		{
+			if (PlayerResults.back().player_id == 1)
+			{
+				return ResultType::Player2Win;
+			}
+			else
+			{
+				return ResultType::Player1Win;
+			}
 
-        }
-    }
-    return ResultType::ProcessingReplay;
+		}
+	}
+	return ResultType::ProcessingReplay;
 }
 
 bool LadderManager::SendDataToConnection(sc2::Connection *Connection, const SC2APIProtocol::Request *request)
 {
-    if (Connection->connection_ != nullptr)
-    {
-        Connection->Send(request);
-        return true;
-    }
-    return false;
+	if (Connection->connection_ != nullptr)
+	{
+		Connection->Send(request);
+		return true;
+	}
+	return false;
 }
 
 GameResult LadderManager::StartGameVsDefault(const BotConfig &Agent1, sc2::Race CompRace, sc2::Difficulty CompDifficulty, const std::string &Map)
 {
-    using namespace std::chrono_literals;
-    // Setup server that mimicks sc2.
-    std::string Agent1Path = GetBotCommandLine(Agent1, 5677, PORT_START, "", true, sc2::Race::Random, CompDifficulty);
-    if (Agent1Path == "" )
-    {
-        return GameResult();
-    }
+	using namespace std::chrono_literals;
+	// Setup server that mimicks sc2.
+	std::string Agent1Path = GetBotCommandLine(Agent1, 5677, PORT_START, "", true, sc2::Race::Random, CompDifficulty);
+	if (Agent1Path == "" )
+	{
+		return GameResult();
+	}
 
-    sc2::Server server;
+	sc2::Server server;
 
-    server.Listen("5677", "100000", "100000", "5");
+	server.Listen("5677", "100000", "100000", "5");
 
-    // Find game executable and run it.
-    sc2::ProcessSettings process_settings;
-    sc2::GameSettings game_settings;
-    sc2::ParseSettings(CoordinatorArgc, CoordinatorArgv, process_settings, game_settings);
-    uint64_t BotProcessId = sc2::StartProcess(process_settings.process_path,
-    { "-listen", "127.0.0.1",
-      "-port", "5679",
-      "-displayMode", "0",
-      "-dataVersion", process_settings.data_version }
-                                              );
+	// Find game executable and run it.
+	sc2::ProcessSettings process_settings;
+	sc2::GameSettings game_settings;
+	sc2::ParseSettings(CoordinatorArgc, CoordinatorArgv, process_settings, game_settings);
+	uint64_t BotProcessId = sc2::StartProcess(process_settings.process_path,
+	{ "-listen", "127.0.0.1",
+	  "-port", "5679",
+	  "-displayMode", "0",
+	  "-dataVersion", process_settings.data_version }
+											  );
 
-    // Connect to running sc2 process.
-    sc2::Connection client;
-    client.Connect("127.0.0.1", 5679, false);
-    int connectionAttemptsClient = 0;
-    while (!client.Connect("127.0.0.1", 5679, false))
-    {
-        connectionAttemptsClient++;
-        sc2::SleepFor(1000);
-        if (connectionAttemptsClient > 60)
-        {
-            PrintThread{} << "Failed to connect client 1. BotProcessID: " << BotProcessId << std::endl;
-            return GameResult();
-        }
-    }
+	// Connect to running sc2 process.
+	sc2::Connection client;
+	client.Connect("127.0.0.1", 5679, false);
+	int connectionAttemptsClient = 0;
+	while (!client.Connect("127.0.0.1", 5679, false))
+	{
+		connectionAttemptsClient++;
+		sc2::SleepFor(1000);
+		if (connectionAttemptsClient > 60)
+		{
+			PrintThread{} << "Failed to connect client 1. BotProcessID: " << BotProcessId << std::endl;
+			return GameResult();
+		}
+	}
 
-    std::vector<sc2::PlayerSetup> Players;
-    Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent1.Race, nullptr, sc2::Easy));
-    Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Computer, sc2::Race::Random, nullptr, CompDifficulty));
-    sc2::GameRequestPtr Create_game_request = CreateStartGameRequest(Map, Players, process_settings);
-    SendDataToConnection(&client, Create_game_request.get());
+	std::vector<sc2::PlayerSetup> Players;
+	Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent1.Race, nullptr, sc2::Easy));
+	Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Computer, sc2::Race::Random, nullptr, CompDifficulty));
+	sc2::GameRequestPtr Create_game_request = CreateStartGameRequest(Map, Players, process_settings);
+	SendDataToConnection(&client, Create_game_request.get());
 
-    SC2APIProtocol::Response* create_response = nullptr;
-    if (client.Receive(create_response, 100000))
-    {
-        PrintThread{} << "Recieved create game response " << create_response->data().DebugString() << std::endl;
-        if (ProcessResponse(create_response->create_game()))
-        {
-            PrintThread{} << "Create game successful" << std::endl << std::endl;
-        }
-    }
-    unsigned long ProcessId;
-    auto bot1ProgramThread = std::thread(StartBotProcess,Agent1, Agent1Path, &ProcessId);
-    sc2::SleepFor(1000);
+	SC2APIProtocol::Response* create_response = nullptr;
+	if (client.Receive(create_response, 100000))
+	{
+		PrintThread{} << "Recieved create game response " << create_response->data().DebugString() << std::endl;
+		if (ProcessResponse(create_response->create_game()))
+		{
+			PrintThread{} << "Create game successful" << std::endl << std::endl;
+		}
+	}
+	unsigned long ProcessId;
+	auto bot1ProgramThread = std::thread(StartBotProcess,Agent1, Agent1Path, &ProcessId);
+	sc2::SleepFor(1000);
 
-    PrintThread{} << "Monitoring client of: " << Agent1.BotName << std::endl;
-    float_t AvgFrameTime = 0;
-    int32_t GameLoop;
-    auto bot1UpdateThread = std::async(GameUpdate, &client, &server,&Agent1.BotName, MaxGameTime, MaxRealGameTime, &AvgFrameTime, &GameLoop);
-    sc2::SleepFor(1000);
+	PrintThread{} << "Monitoring client of: " << Agent1.BotName << std::endl;
+	float_t AvgFrameTime = 0;
+	int32_t GameLoop;
+	auto bot1UpdateThread = std::async(GameUpdate, &client, &server,&Agent1.BotName, MaxGameTime, MaxRealGameTime, &AvgFrameTime, &GameLoop);
+	sc2::SleepFor(1000);
 
-    ResultType CurrentResult = ResultType::InitializationError;
-    bool GameRunning = true;
-    //sc2::ProtoInterface proto_1;
-    //std::vector<sc2::PlayerResult> Player1Results;
-    SleepFor(10000);
-    while (GameRunning)
-    {
+	ResultType CurrentResult = ResultType::InitializationError;
+	bool GameRunning = true;
+	//sc2::ProtoInterface proto_1;
+	//std::vector<sc2::PlayerResult> Player1Results;
+	SleepFor(10000);
+	while (GameRunning)
+	{
 
-        auto update1status = bot1UpdateThread.wait_for(1s);
-        if (update1status == std::future_status::ready)
-        {
-            ExitCase BotExitCase = bot1UpdateThread.get();
-            if (BotExitCase == ExitCase::ClientRequestExit)
-            {
-                // If Player 1 has requested exit, he has surrendered, and player 2 is awarded the win
-                CurrentResult = ResultType::Player2Win;
-            }
-            else if (BotExitCase == ExitCase::ClientTimeout)
-            {
-                CurrentResult = ResultType::Player1Crash;
-            }
-            else if (BotExitCase == ExitCase::GameTimeout)
-            {
-                CurrentResult = ResultType::Timeout;
-            }
-            else
-            {
-                CurrentResult = ResultType::ProcessingReplay;
-            }
+		auto update1status = bot1UpdateThread.wait_for(1s);
+		if (update1status == std::future_status::ready)
+		{
+			ExitCase BotExitCase = bot1UpdateThread.get();
+			if (BotExitCase == ExitCase::ClientRequestExit)
+			{
+				// If Player 1 has requested exit, he has surrendered, and player 2 is awarded the win
+				CurrentResult = ResultType::Player2Win;
+			}
+			else if (BotExitCase == ExitCase::ClientTimeout)
+			{
+				CurrentResult = ResultType::Player1Crash;
+			}
+			else if (BotExitCase == ExitCase::GameTimeout)
+			{
+				CurrentResult = ResultType::Timeout;
+			}
+			else
+			{
+				CurrentResult = ResultType::ProcessingReplay;
+			}
 
-            GameRunning = false;
-            break;
-        }
-    }
-    if (CurrentResult == ResultType::ProcessingReplay)
-    {
-        CurrentResult = GetPlayerResults(&client);
-    }
+			GameRunning = false;
+			break;
+		}
+	}
+	if (CurrentResult == ResultType::ProcessingReplay)
+	{
+		CurrentResult = GetPlayerResults(&client);
+	}
 
-    std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
-    std::string ReplayFile = ReplayDir + Agent1.BotName + "v" + GetDifficultyString(CompDifficulty) + "-" + RemoveMapExtension(Map) + ".Sc2Replay";
-    ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
+	std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
+	std::string ReplayFile = ReplayDir + Agent1.BotName + "v" + GetDifficultyString(CompDifficulty) + "-" + RemoveMapExtension(Map) + ".Sc2Replay";
+	ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
 
-    SaveReplay(&client, ReplayFile);
-    if (!SendDataToConnection(&client, CreateLeaveGameRequest().get()))
-    {
-        PrintThread{} << "CreateLeaveGameRequest failed" << std::endl;
-    }
+	SaveReplay(&client, ReplayFile);
+	if (!SendDataToConnection(&client, CreateLeaveGameRequest().get()))
+	{
+		PrintThread{} << "CreateLeaveGameRequest failed" << std::endl;
+	}
 
-    bot1ProgramThread.join();
-    GameResult result;
-    result.Result = CurrentResult;
-    return result;
+	bot1ProgramThread.join();
+	GameResult result;
+	result.Result = CurrentResult;
+	return result;
 }
 
 GameResult LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Agent2, const std::string &Map)
 {
 
-    using namespace std::chrono_literals;
-    // Setup server that mimicks sc2.
-    std::string Agent1Path = GetBotCommandLine(Agent1, 5677, PORT_START, Agent2.PlayerId);
-    std::string Agent2Path = GetBotCommandLine(Agent2, 5678, PORT_START, Agent1.PlayerId);
-    if (Agent1Path == "" || Agent2Path == "")
-    {
-        return GameResult();
-    }
-    sc2::Server server;
-    sc2::Server server2;
-    server.Listen("5677", "100000", "100000", "5");
-    server2.Listen("5678", "100000", "100000", "5");
-    // Find game executable and run it.
-    sc2::ProcessSettings process_settings;
-    sc2::GameSettings game_settings;
-    sc2::ParseSettings(CoordinatorArgc, CoordinatorArgv, process_settings, game_settings);
-    uint64_t GameClientPid1 = sc2::StartProcess(process_settings.process_path,
-    { "-listen", "127.0.0.1",
-      "-port", "5679",
-      "-displayMode", "0",
-      "-dataVersion", process_settings.data_version }
-                                                );
-    uint64_t GameClientPid2 = sc2::StartProcess(process_settings.process_path,
-    { "-listen", "127.0.0.1",
-      "-port", "5680",
-      "-displayMode", "0",
-      "-dataVersion", process_settings.data_version }
-                                                );
+	using namespace std::chrono_literals;
+	// Setup server that mimicks sc2.
+	std::string Agent1Path = GetBotCommandLine(Agent1, 5677, PORT_START, Agent2.PlayerId);
+	std::string Agent2Path = GetBotCommandLine(Agent2, 5678, PORT_START, Agent1.PlayerId);
+	if (Agent1Path == "" || Agent2Path == "")
+	{
+		return GameResult();
+	}
+	sc2::Server server;
+	sc2::Server server2;
+	server.Listen("5677", "100000", "100000", "5");
+	server2.Listen("5678", "100000", "100000", "5");
+	// Find game executable and run it.
+	sc2::ProcessSettings process_settings;
+	sc2::GameSettings game_settings;
+	sc2::ParseSettings(CoordinatorArgc, CoordinatorArgv, process_settings, game_settings);
+	uint64_t GameClientPid1 = sc2::StartProcess(process_settings.process_path,
+	{ "-listen", "127.0.0.1",
+	  "-port", "5679",
+	  "-displayMode", "0",
+	  "-dataVersion", process_settings.data_version }
+												);
+	uint64_t GameClientPid2 = sc2::StartProcess(process_settings.process_path,
+	{ "-listen", "127.0.0.1",
+	  "-port", "5680",
+	  "-displayMode", "0",
+	  "-dataVersion", process_settings.data_version }
+												);
 
-    // Connect to running sc2 process.
-    sc2::Connection client;
-    int connectionAttemptsClient1 = 0;
-    while (!client.Connect("127.0.0.1", 5679, false))
-    {
-        connectionAttemptsClient1++;
-        sc2::SleepFor(1000);
-        if (connectionAttemptsClient1 > 60)
-        {
-            PrintThread{} << "Failed to connect client 1. BotProcessID: " << GameClientPid1 << std::endl;
-            return GameResult();
-        }
-    }
-    sc2::Connection client2;
-    int connectionAttemptsClient2 = 0;
-    while (!client2.Connect("127.0.0.1", 5680, false))
-    {
-        connectionAttemptsClient2++;
-        sc2::SleepFor(1000);
-        if (connectionAttemptsClient2 > 60)
-        {
-            PrintThread{} << "Failed to connect client 2. BotProcessID: " << GameClientPid2 << std::endl;
-            return GameResult();
-        }
-    }
+	// Connect to running sc2 process.
+	sc2::Connection client;
+	int connectionAttemptsClient1 = 0;
+	while (!client.Connect("127.0.0.1", 5679, false))
+	{
+		connectionAttemptsClient1++;
+		sc2::SleepFor(1000);
+		if (connectionAttemptsClient1 > 60)
+		{
+			PrintThread{} << "Failed to connect client 1. BotProcessID: " << GameClientPid1 << std::endl;
+			return GameResult();
+		}
+	}
+	sc2::Connection client2;
+	int connectionAttemptsClient2 = 0;
+	while (!client2.Connect("127.0.0.1", 5680, false))
+	{
+		connectionAttemptsClient2++;
+		sc2::SleepFor(1000);
+		if (connectionAttemptsClient2 > 60)
+		{
+			PrintThread{} << "Failed to connect client 2. BotProcessID: " << GameClientPid2 << std::endl;
+			return GameResult();
+		}
+	}
 
-    std::vector<sc2::PlayerSetup> Players;
+	std::vector<sc2::PlayerSetup> Players;
 
-    Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent1.Race, nullptr, sc2::Easy));
-    Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent2.Race, nullptr, sc2::Easy));
-    sc2::GameRequestPtr Create_game_request = CreateStartGameRequest(Map, Players, process_settings);
-    client.Send(Create_game_request.get());
-    SC2APIProtocol::Response* create_response = nullptr;
-    if (client.Receive(create_response, 100000))
-    {
-        PrintThread{} << "Recieved create game response " << create_response->data().DebugString() << std::endl;
-        if (ProcessResponse(create_response->create_game()))
-        {
-            PrintThread{} << "Create game successful" << std::endl << std::endl;
-        }
-    }
-    unsigned long Bot1ThreadId = 0;
-    unsigned long Bot2ThreadId = 0;
-    auto bot1ProgramThread = std::async(&StartBotProcess, Agent1, Agent1Path, &Bot1ThreadId);
-    auto bot2ProgramThread = std::async(&StartBotProcess, Agent2, Agent2Path, &Bot2ThreadId);
-    sc2::SleepFor(500);
-    sc2::SleepFor(500);
+	Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent1.Race, nullptr, sc2::Easy));
+	Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent2.Race, nullptr, sc2::Easy));
+	sc2::GameRequestPtr Create_game_request = CreateStartGameRequest(Map, Players, process_settings);
+	client.Send(Create_game_request.get());
+	SC2APIProtocol::Response* create_response = nullptr;
+	if (client.Receive(create_response, 100000))
+	{
+		PrintThread{} << "Recieved create game response " << create_response->data().DebugString() << std::endl;
+		if (ProcessResponse(create_response->create_game()))
+		{
+			PrintThread{} << "Create game successful" << std::endl << std::endl;
+		}
+	}
+	unsigned long Bot1ThreadId = 0;
+	unsigned long Bot2ThreadId = 0;
+	auto bot1ProgramThread = std::async(&StartBotProcess, Agent1, Agent1Path, &Bot1ThreadId);
+	auto bot2ProgramThread = std::async(&StartBotProcess, Agent2, Agent2Path, &Bot2ThreadId);
+	sc2::SleepFor(500);
+	sc2::SleepFor(500);
 
-    //toDo check here already if the bots crashed.
-    float_t Bot1AvgFrame = 0;
-    float_t Bot2AvgFrame = 0;
-    int32_t GameLoop;
-    auto bot1UpdateThread = std::async(&GameUpdate, &client, &server, &Agent1.BotName, MaxGameTime, MaxRealGameTime, &Bot1AvgFrame, &GameLoop);
-    auto bot2UpdateThread = std::async(&GameUpdate, &client2, &server2, &Agent2.BotName, MaxGameTime, MaxRealGameTime, &Bot2AvgFrame, nullptr);
-    sc2::SleepFor(1000);
+	//toDo check here already if the bots crashed.
+	float_t Bot1AvgFrame = 0;
+	float_t Bot2AvgFrame = 0;
+	int32_t GameLoop;
+	auto bot1UpdateThread = std::async(&GameUpdate, &client, &server, &Agent1.BotName, MaxGameTime, MaxRealGameTime, &Bot1AvgFrame, &GameLoop);
+	auto bot2UpdateThread = std::async(&GameUpdate, &client2, &server2, &Agent2.BotName, MaxGameTime, MaxRealGameTime, &Bot2AvgFrame, nullptr);
+	sc2::SleepFor(1000);
 
-    ResultType CurrentResult = ResultType::InitializationError;
-    bool GameRunning = true;
-    //sc2::ProtoInterface proto_1;
-    while (GameRunning)
-    {
-        auto update1status = bot1UpdateThread.wait_for(1s);
-        auto update2status = bot2UpdateThread.wait_for(0ms);
-        auto thread1Status = bot1ProgramThread.wait_for(0ms);
-        auto thread2Status = bot2ProgramThread.wait_for(0ms);
-        if (update1status == std::future_status::ready)
-        {
-            ExitCase BotExitCase = bot1UpdateThread.get();
-            if (BotExitCase == ExitCase::ClientRequestExit)
-            {
-                // If Player 1 has requested exit, he has surrendered, and player 2 is awarded the win
-                CurrentResult = ResultType::Player2Win;
-            }
-            else if( BotExitCase == ExitCase::ClientTimeout)
-            {
-                CurrentResult = ResultType::Player1Crash;
-            }
-            else if (BotExitCase == ExitCase::GameTimeout)
-            {
-                CurrentResult = ResultType::Timeout;
-            }
-            else
-            {
-                CurrentResult = ResultType::ProcessingReplay;
-            }
+	ResultType CurrentResult = ResultType::InitializationError;
+	bool GameRunning = true;
+	//sc2::ProtoInterface proto_1;
+	while (GameRunning)
+	{
+		auto update1status = bot1UpdateThread.wait_for(1s);
+		auto update2status = bot2UpdateThread.wait_for(0ms);
+		auto thread1Status = bot1ProgramThread.wait_for(0ms);
+		auto thread2Status = bot2ProgramThread.wait_for(0ms);
+		if (update1status == std::future_status::ready)
+		{
+			ExitCase BotExitCase = bot1UpdateThread.get();
+			if (BotExitCase == ExitCase::ClientRequestExit)
+			{
+				// If Player 1 has requested exit, he has surrendered, and player 2 is awarded the win
+				CurrentResult = ResultType::Player2Win;
+			}
+			else if( BotExitCase == ExitCase::ClientTimeout)
+			{
+				CurrentResult = ResultType::Player1Crash;
+			}
+			else if (BotExitCase == ExitCase::GameTimeout)
+			{
+				CurrentResult = ResultType::Timeout;
+			}
+			else
+			{
+				CurrentResult = ResultType::ProcessingReplay;
+			}
 
-            GameRunning = false;
-            break;
-        }
-        if(update2status == std::future_status::ready)
-        {
-            ExitCase BotExitCase = bot2UpdateThread.get();
-            if (BotExitCase == ExitCase::ClientRequestExit)
-            {
-                // If Player 2 has requested exit, he has surrendered, and player 1 is awarded the win
-                CurrentResult = ResultType::Player1Win;
-            }
-            else if (BotExitCase == ExitCase::ClientTimeout)
-            {
-                CurrentResult = ResultType::Player2Crash;
-            }
-            else if (BotExitCase == ExitCase::GameTimeout)
-            {
-                CurrentResult = ResultType::Timeout;
-            }
-            else
-            {
-                CurrentResult = ResultType::ProcessingReplay;
-            }
+			GameRunning = false;
+			break;
+		}
+		if(update2status == std::future_status::ready)
+		{
+			ExitCase BotExitCase = bot2UpdateThread.get();
+			if (BotExitCase == ExitCase::ClientRequestExit)
+			{
+				// If Player 2 has requested exit, he has surrendered, and player 1 is awarded the win
+				CurrentResult = ResultType::Player1Win;
+			}
+			else if (BotExitCase == ExitCase::ClientTimeout)
+			{
+				CurrentResult = ResultType::Player2Crash;
+			}
+			else if (BotExitCase == ExitCase::GameTimeout)
+			{
+				CurrentResult = ResultType::Timeout;
+			}
+			else
+			{
+				CurrentResult = ResultType::ProcessingReplay;
+			}
 
-            GameRunning = false;
-            break;
-        }
-        if (thread1Status == std::future_status::ready)
-        {
-            CurrentResult = ResultType::Player1Crash;
-            GameRunning = false;
-        }
-        if (thread2Status == std::future_status::ready)
-        {
-            CurrentResult = ResultType::Player2Crash;
-            GameRunning = false;
-        }
+			GameRunning = false;
+			break;
+		}
+		if (thread1Status == std::future_status::ready)
+		{
+			CurrentResult = ResultType::Player1Crash;
+			GameRunning = false;
+		}
+		if (thread2Status == std::future_status::ready)
+		{
+			CurrentResult = ResultType::Player2Crash;
+			GameRunning = false;
+		}
 
-    }
-    if (CurrentResult == ResultType::ProcessingReplay)
-    {
-        CurrentResult = GetPlayerResults(&client);
-    }
-    if (CurrentResult == ResultType::ProcessingReplay)
-    {
-        CurrentResult = GetPlayerResults(&client2);
-    }
-    sc2::SleepFor(1000);
-    std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
+	}
+	if (CurrentResult == ResultType::ProcessingReplay)
+	{
+		CurrentResult = GetPlayerResults(&client);
+	}
+	if (CurrentResult == ResultType::ProcessingReplay)
+	{
+		CurrentResult = GetPlayerResults(&client2);
+	}
+	sc2::SleepFor(1000);
+	std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
 
-    std::string ReplayFile = ReplayDir + Agent1.BotName + "v" + Agent2.BotName + "-" + RemoveMapExtension(Map) + ".SC2Replay";
-    ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
-    if (!SaveReplay(&client, ReplayFile))
-    {
-        SaveReplay(&client2, ReplayFile);
-    }
-    sc2::SleepFor(1000);
-    ChangeBotNames(ReplayFile, Agent1.BotName, Agent2.BotName);
-    auto bot1OnEndThread = std::async(&OnEnd, &client, &server, &Agent1.BotName);
-    auto bot2OnEndThread = std::async(&OnEnd, &client2, &server2, &Agent2.BotName);
-    sc2::SleepFor(1000);
-    if (!SendDataToConnection(&client, CreateLeaveGameRequest().get()))
-    {
-        PrintThread{} << "CreateLeaveGameRequest failed for Client 1." << std::endl;
-    }
-    sc2::SleepFor(1000);
-    if (!SendDataToConnection(&client2, CreateLeaveGameRequest().get()))
-    {
-        PrintThread{} << "CreateLeaveGameRequest failed for Client 2." << std::endl;
-    }
-    sc2::SleepFor(1000);
-    PrintThread{} << "test " << server.connections_.size() << std::endl;
-    PrintThread{} << "test " << server2.connections_.size() << std::endl;
-    sc2::SleepFor(5000);
-    sc2::TerminateProcess(GameClientPid1);
-    sc2::TerminateProcess(GameClientPid2);
-    sc2::SleepFor(5000);
-    if (server.HasRequest() && server.connections_.size() > 0)
-    {
-        server.SendRequest(client.connection_);
-    }
-    sc2::SleepFor(1000);
-    if (server2.HasRequest() && server2.connections_.size() > 0)
-    {
-        server2.SendRequest(client2.connection_);
-    }
-    /*
-    if (CurrentResult == Player1Crash || CurrentResult == Player2Crash)
-    {
-        sc2::SleepFor(5000);
-        sc2::TerminateProcess(GameClientPid1);
-        sc2::TerminateProcess(GameClientPid2);
-        sc2::SleepFor(5000);
-        try
-        {
-            bot1UpdateThread.wait();
-            bot2UpdateThread.wait();
+	std::string ReplayFile = ReplayDir + Agent1.BotName + "v" + Agent2.BotName + "-" + RemoveMapExtension(Map) + ".SC2Replay";
+	ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
+	if (!SaveReplay(&client, ReplayFile))
+	{
+		SaveReplay(&client2, ReplayFile);
+	}
+	sc2::SleepFor(1000);
+	ChangeBotNames(ReplayFile, Agent1.BotName, Agent2.BotName);
+	auto bot1OnEndThread = std::async(&OnEnd, &client, &server, &Agent1.BotName);
+	auto bot2OnEndThread = std::async(&OnEnd, &client2, &server2, &Agent2.BotName);
+	sc2::SleepFor(1000);
+	if (!SendDataToConnection(&client, CreateLeaveGameRequest().get()))
+	{
+		PrintThread{} << "CreateLeaveGameRequest failed for Client 1." << std::endl;
+	}
+	sc2::SleepFor(1000);
+	if (!SendDataToConnection(&client2, CreateLeaveGameRequest().get()))
+	{
+		PrintThread{} << "CreateLeaveGameRequest failed for Client 2." << std::endl;
+	}
+	sc2::SleepFor(1000);
+	PrintThread{} << "test " << server.connections_.size() << std::endl;
+	PrintThread{} << "test " << server2.connections_.size() << std::endl;
+	sc2::SleepFor(5000);
+	sc2::TerminateProcess(GameClientPid1);
+	sc2::TerminateProcess(GameClientPid2);
+	sc2::SleepFor(5000);
+	if (server.HasRequest() && server.connections_.size() > 0)
+	{
+		server.SendRequest(client.connection_);
+	}
+	sc2::SleepFor(1000);
+	if (server2.HasRequest() && server2.connections_.size() > 0)
+	{
+		server2.SendRequest(client2.connection_);
+	}
+	/*
+	if (CurrentResult == Player1Crash || CurrentResult == Player2Crash)
+	{
+		sc2::SleepFor(5000);
+		sc2::TerminateProcess(GameClientPid1);
+		sc2::TerminateProcess(GameClientPid2);
+		sc2::SleepFor(5000);
+		try
+		{
+			bot1UpdateThread.wait();
+			bot2UpdateThread.wait();
 
-        }
-        catch (const std::exception& e)
-        {
-            PrintThread{} << e.what() << std::endl <<" Unable to detect end of update thread.  Continuing" << std::endl;
-        }
+		}
+		catch (const std::exception& e)
+		{
+			PrintThread{} << e.what() << std::endl <<" Unable to detect end of update thread.  Continuing" << std::endl;
+		}
 
-    }
-    std::future_status bot1ProgStatus, bot2ProgStatus;
-    auto start = std::chrono::system_clock::now();
-    std::chrono::duration<double> elapsed_seconds;
-    while (elapsed_seconds.count() < 20)
-    {
-        bot1ProgStatus = bot1ProgramThread.wait_for(50ms);
-        bot2ProgStatus = bot2ProgramThread.wait_for(50ms);
-        if (bot1ProgStatus == std::future_status::ready && bot2ProgStatus == std::future_status::ready)
-        {
-            break;
-        }
-        elapsed_seconds = std::chrono::system_clock::now() - start;
-    }
-    if (bot1ProgStatus != std::future_status::ready)
-    {
-        PrintThread{} << "Failed to detect end of " << Agent1.BotName << " after 20s.  Killing" << std::endl;
-        KillBotProcess(Bot1ThreadId);
-    }
-    if (bot2ProgStatus != std::future_status::ready)
-    {
-        PrintThread{} << "Failed to detect end of " << Agent2.BotName << " after 20s.  Killing" << std::endl;
-        KillBotProcess(Bot2ThreadId);
-    }
-    */
-    GameResult Result;
-    Result.Result = CurrentResult;
-    Result.Bot1AvgFrame = Bot1AvgFrame;
-    Result.Bot2AvgFrame = Bot2AvgFrame;
-    Result.GameLoop = GameLoop;
-    return Result;
+	}
+	std::future_status bot1ProgStatus, bot2ProgStatus;
+	auto start = std::chrono::system_clock::now();
+	std::chrono::duration<double> elapsed_seconds;
+	while (elapsed_seconds.count() < 20)
+	{
+		bot1ProgStatus = bot1ProgramThread.wait_for(50ms);
+		bot2ProgStatus = bot2ProgramThread.wait_for(50ms);
+		if (bot1ProgStatus == std::future_status::ready && bot2ProgStatus == std::future_status::ready)
+		{
+			break;
+		}
+		elapsed_seconds = std::chrono::system_clock::now() - start;
+	}
+	if (bot1ProgStatus != std::future_status::ready)
+	{
+		PrintThread{} << "Failed to detect end of " << Agent1.BotName << " after 20s.  Killing" << std::endl;
+		KillBotProcess(Bot1ThreadId);
+	}
+	if (bot2ProgStatus != std::future_status::ready)
+	{
+		PrintThread{} << "Failed to detect end of " << Agent2.BotName << " after 20s.  Killing" << std::endl;
+		KillBotProcess(Bot2ThreadId);
+	}
+	*/
+	GameResult Result;
+	Result.Result = CurrentResult;
+	Result.Bot1AvgFrame = Bot1AvgFrame;
+	Result.Bot2AvgFrame = Bot2AvgFrame;
+	Result.GameLoop = GameLoop;
+	return Result;
 }
 
 
 LadderManager::LadderManager(int InCoordinatorArgc, char** inCoordinatorArgv)
 
-    : coordinator(nullptr)
-    , CoordinatorArgc(InCoordinatorArgc)
-    , CoordinatorArgv(inCoordinatorArgv)
-    , MaxGameTime(0)
-    , MaxRealGameTime(0)
-    , MaxEloDiff(0)
-    , ConfigFile("LadderManager.json")
-    , EnableReplayUploads(false)
-    , EnableServerLogin(false)
-    , EnablePlayerIds(false)
-    , Sc2Launched(false)
-    , Config(nullptr)
-    , PlayerIds(nullptr)
+	: coordinator(nullptr)
+	, CoordinatorArgc(InCoordinatorArgc)
+	, CoordinatorArgv(inCoordinatorArgv)
+	, MaxGameTime(0)
+	, MaxRealGameTime(0)
+	, MaxEloDiff(0)
+	, ConfigFile("LadderManager.json")
+	, EnableReplayUploads(false)
+	, EnableServerLogin(false)
+	, EnablePlayerIds(false)
+	, Sc2Launched(false)
+	, Config(nullptr)
+	, PlayerIds(nullptr)
 {
 }
 
 // Used for tests
 LadderManager::LadderManager(int InCoordinatorArgc, char** inCoordinatorArgv, const char *InConfigFile)
 
-    : coordinator(nullptr)
-    , CoordinatorArgc(InCoordinatorArgc)
-    , CoordinatorArgv(inCoordinatorArgv)
-    , MaxGameTime(0)
-    , MaxRealGameTime(0)
-    , MaxEloDiff(0)
-    , ConfigFile(InConfigFile)
-    , EnableReplayUploads(false)
-    , EnableServerLogin(false)
-    , EnablePlayerIds(false)
-    , Sc2Launched(false)
-    , Config(nullptr)
-    , PlayerIds(nullptr)
+	: coordinator(nullptr)
+	, CoordinatorArgc(InCoordinatorArgc)
+	, CoordinatorArgv(inCoordinatorArgv)
+	, MaxGameTime(0)
+	, MaxRealGameTime(0)
+	, MaxEloDiff(0)
+	, ConfigFile(InConfigFile)
+	, EnableReplayUploads(false)
+	, EnableServerLogin(false)
+	, EnablePlayerIds(false)
+	, Sc2Launched(false)
+	, Config(nullptr)
+	, PlayerIds(nullptr)
 {
 }
 
 std::string LadderManager::GerneratePlayerId(size_t Length)
 {
-    static const char hexdigit[16] = { '0', '1','2','3','4','5','6','7','8','9','a','b','c','d','e','f' };
-    std::string outstring;
-    if (Length < 1)
-    {
-        return outstring;
+	static const char hexdigit[16] = { '0', '1','2','3','4','5','6','7','8','9','a','b','c','d','e','f' };
+	std::string outstring;
+	if (Length < 1)
+	{
+		return outstring;
 
-    }
-    --Length;
-    for (int i = 0; i < Length; ++i)
-    {
-        outstring.append(1, hexdigit[rand() % sizeof hexdigit]);
-    }
-    return outstring;
+	}
+	--Length;
+	for (int i = 0; i < Length; ++i)
+	{
+		outstring.append(1, hexdigit[rand() % sizeof hexdigit]);
+	}
+	return outstring;
 }
 
 bool LadderManager::LoadSetup()
 {
-    delete Config;
-    Config = new LadderConfig(ConfigFile);
-    if (!Config->ParseConfig())
-    {
-        PrintThread{} << "Unable to parse config (not found or not valid): " << ConfigFile << std::endl;
-        return false;
-    }
+	delete Config;
+	Config = new LadderConfig(ConfigFile);
+	if (!Config->ParseConfig())
+	{
+		PrintThread{} << "Unable to parse config (not found or not valid): " << ConfigFile << std::endl;
+		return false;
+	}
 
-    std::string PlayerIdFile = Config->GetValue("PlayerIdFile");
-    if (PlayerIdFile.length() > 0)
-    {
-        PlayerIds = new LadderConfig(PlayerIdFile);
-        EnablePlayerIds = true;
-    }
+	std::string PlayerIdFile = Config->GetValue("PlayerIdFile");
+	if (PlayerIdFile.length() > 0)
+	{
+		PlayerIds = new LadderConfig(PlayerIdFile);
+		EnablePlayerIds = true;
+	}
 
-    std::string MaxGameTimeString = Config->GetValue("MaxGameTime");
-    if (MaxGameTimeString.length() > 0)
-    {
-        MaxGameTime = std::stoi(MaxGameTimeString);
-    }
-    std::string MaxRealGameTimeString = Config->GetValue("MaxRealGameTime");
-    if (MaxRealGameTimeString.length() > 0)
-    {
-        MaxRealGameTime = std::stoi(MaxRealGameTimeString);
-    }
+	std::string MaxGameTimeString = Config->GetValue("MaxGameTime");
+	if (MaxGameTimeString.length() > 0)
+	{
+		MaxGameTime = std::stoi(MaxGameTimeString);
+	}
+	std::string MaxRealGameTimeString = Config->GetValue("MaxRealGameTime");
+	if (MaxRealGameTimeString.length() > 0)
+	{
+		MaxRealGameTime = std::stoi(MaxRealGameTimeString);
+	}
 
-    std::string EnableReplayUploadString = Config->GetValue("EnableReplayUpload");
-    if (EnableReplayUploadString == "True")
-    {
-        EnableReplayUploads = true;
-    }
+	std::string EnableReplayUploadString = Config->GetValue("EnableReplayUpload");
+	if (EnableReplayUploadString == "True")
+	{
+		EnableReplayUploads = true;
+	}
 
-    ResultsLogFile = Config->GetValue("ResultsLogFile");
+	ResultsLogFile = Config->GetValue("ResultsLogFile");
 
-    std::string EnableServerLoginString = Config->GetValue("EnableServerLogin");
-    if (EnableServerLoginString == "True")
-    {
-        EnableServerLogin = true;
-        ServerLoginAddress = Config->GetValue("ServerLoginAddress");
-        ServerUsername = Config->GetValue("ServerUsername");
-        ServerPassword = Config->GetValue("ServerPassword");
-    }
-    BotCheckLocation = Config->GetValue("BotInfoLocation");
+	std::string EnableServerLoginString = Config->GetValue("EnableServerLogin");
+	if (EnableServerLoginString == "True")
+	{
+		EnableServerLogin = true;
+		ServerLoginAddress = Config->GetValue("ServerLoginAddress");
+		ServerUsername = Config->GetValue("ServerUsername");
+		ServerPassword = Config->GetValue("ServerPassword");
+	}
+	BotCheckLocation = Config->GetValue("BotInfoLocation");
 
-    std::string MaxEloDiffStr = Config->GetValue("MaxEloDiff");
-    if (MaxEloDiffStr.length() > 0)
-    {
-        MaxEloDiff = std::stoi(MaxEloDiffStr);
-    }
+	std::string MaxEloDiffStr = Config->GetValue("MaxEloDiff");
+	if (MaxEloDiffStr.length() > 0)
+	{
+		MaxEloDiff = std::stoi(MaxEloDiffStr);
+	}
 
-    return true;
+	return true;
 }
 
 void LadderManager::SaveJsonResult(const BotConfig &Bot1, const BotConfig &Bot2, const std::string  &Map, GameResult Result)
 {
-    rapidjson::Document ResultsDoc;
-    rapidjson::Document OriginalResults;
-    rapidjson::Document::AllocatorType& alloc = ResultsDoc.GetAllocator();
-    ResultsDoc.SetObject();
-    rapidjson::Value ResultsArray(rapidjson::kArrayType);
-    std::ifstream ifs(ResultsLogFile.c_str());
-    if (ifs)
-    {
-        std::stringstream buffer;
-        buffer << ifs.rdbuf();
-        bool parsingFailed = OriginalResults.Parse(buffer.str()).HasParseError();
-        if (!parsingFailed && OriginalResults.HasMember("Results"))
-        {
-            const rapidjson::Value & Results = OriginalResults["Results"];
-            for (const auto& val : Results.GetArray())
-            {
-                rapidjson::Value NewVal;
-                NewVal.CopyFrom(val, alloc);
-                ResultsArray.PushBack(NewVal, alloc);
-            }
-        }
-    }
+	rapidjson::Document ResultsDoc;
+	rapidjson::Document OriginalResults;
+	rapidjson::Document::AllocatorType& alloc = ResultsDoc.GetAllocator();
+	ResultsDoc.SetObject();
+	rapidjson::Value ResultsArray(rapidjson::kArrayType);
+	std::ifstream ifs(ResultsLogFile.c_str());
+	if (ifs)
+	{
+		std::stringstream buffer;
+		buffer << ifs.rdbuf();
+		bool parsingFailed = OriginalResults.Parse(buffer.str()).HasParseError();
+		if (!parsingFailed && OriginalResults.HasMember("Results"))
+		{
+			const rapidjson::Value & Results = OriginalResults["Results"];
+			for (const auto& val : Results.GetArray())
+			{
+				rapidjson::Value NewVal;
+				NewVal.CopyFrom(val, alloc);
+				ResultsArray.PushBack(NewVal, alloc);
+			}
+		}
+	}
 
-    rapidjson::Value NewResult(rapidjson::kObjectType);
-    NewResult.AddMember("Bot1", Bot1.BotName, ResultsDoc.GetAllocator());
-    NewResult.AddMember("Bot2", Bot2.BotName, alloc);
-    switch (Result.Result)
-    {
-    case Player1Win:
-    case Player2Crash:
-        NewResult.AddMember("Winner", Bot1.BotName, alloc);
-        break;
-    case Player2Win:
-    case Player1Crash:
-        NewResult.AddMember("Winner", Bot2.BotName, alloc);
-        break;
-    case Tie:
-    case Timeout:
-        NewResult.AddMember("Winner", "Tie", alloc);
-        break;
-    case InitializationError:
-    case Error:
-    case ProcessingReplay:
-        NewResult.AddMember("Winner", "Error", alloc);
-        break;
-    }
+	rapidjson::Value NewResult(rapidjson::kObjectType);
+	NewResult.AddMember("Bot1", Bot1.BotName, ResultsDoc.GetAllocator());
+	NewResult.AddMember("Bot2", Bot2.BotName, alloc);
+	switch (Result.Result)
+	{
+	case Player1Win:
+	case Player2Crash:
+		NewResult.AddMember("Winner", Bot1.BotName, alloc);
+		break;
+	case Player2Win:
+	case Player1Crash:
+		NewResult.AddMember("Winner", Bot2.BotName, alloc);
+		break;
+	case Tie:
+	case Timeout:
+		NewResult.AddMember("Winner", "Tie", alloc);
+		break;
+	case InitializationError:
+	case Error:
+	case ProcessingReplay:
+		NewResult.AddMember("Winner", "Error", alloc);
+		break;
+	}
 
-    NewResult.AddMember("Map", Map, alloc);
-    NewResult.AddMember("Result", GetResultType(Result.Result), alloc);
-    NewResult.AddMember("GameTime", Result.GameLoop, alloc);
-    ResultsArray.PushBack(NewResult, alloc);
-    ResultsDoc.AddMember("Results", ResultsArray, alloc);
-    std::ofstream ofs(ResultsLogFile.c_str());
-    rapidjson::OStreamWrapper osw(ofs);
-    rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(osw);
-    ResultsDoc.Accept(writer);
+	NewResult.AddMember("Map", Map, alloc);
+	NewResult.AddMember("Result", GetResultType(Result.Result), alloc);
+	NewResult.AddMember("GameTime", Result.GameLoop, alloc);
+	ResultsArray.PushBack(NewResult, alloc);
+	ResultsDoc.AddMember("Results", ResultsArray, alloc);
+	std::ofstream ofs(ResultsLogFile.c_str());
+	rapidjson::OStreamWrapper osw(ofs);
+	rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(osw);
+	ResultsDoc.Accept(writer);
 }
 
 
 void LadderManager::LoadAgents()
 {
-    std::string BotConfigFile = Config->GetValue("BotConfigFile");
-    if (BotConfigFile.length() < 1)
-    {
-        return;
-    }
-    std::ifstream t(BotConfigFile);
-    std::stringstream buffer;
-    buffer << t.rdbuf();
-    std::string BotConfigString = buffer.str();
-    rapidjson::Document doc;
-    bool parsingFailed = doc.Parse(BotConfigString.c_str()).HasParseError();
-    if (parsingFailed)
-    {
-        std::cerr << "Unable to parse bot config file: " << BotConfigFile << std::endl;
-        return;
-    }
-    if (doc.HasMember("Bots") && doc["Bots"].IsObject())
-    {
-        const rapidjson::Value & Bots = doc["Bots"];
-        for (auto itr = Bots.MemberBegin(); itr != Bots.MemberEnd(); ++itr)
-        {
-            BotConfig NewBot;
-            NewBot.BotName = itr->name.GetString();
-            const rapidjson::Value &val = itr->value;
+	std::string BotConfigFile = Config->GetValue("BotConfigFile");
+	if (BotConfigFile.length() < 1)
+	{
+		return;
+	}
+	std::ifstream t(BotConfigFile);
+	std::stringstream buffer;
+	buffer << t.rdbuf();
+	std::string BotConfigString = buffer.str();
+	rapidjson::Document doc;
+	bool parsingFailed = doc.Parse(BotConfigString.c_str()).HasParseError();
+	if (parsingFailed)
+	{
+		std::cerr << "Unable to parse bot config file: " << BotConfigFile << std::endl;
+		return;
+	}
+	if (doc.HasMember("Bots") && doc["Bots"].IsObject())
+	{
+		const rapidjson::Value & Bots = doc["Bots"];
+		for (auto itr = Bots.MemberBegin(); itr != Bots.MemberEnd(); ++itr)
+		{
+			BotConfig NewBot;
+			NewBot.BotName = itr->name.GetString();
+			const rapidjson::Value &val = itr->value;
 
-            if (val.HasMember("Race") && val["Race"].IsString())
-            {
-                NewBot.Race = GetRaceFromString(val["Race"].GetString());
-            }
-            else
-            {
-                std::cerr << "Unable to parse race for bot " << NewBot.BotName << std::endl;
-                continue;
-            }
-            if (val.HasMember("Type") && val["Type"].IsString())
-            {
-                NewBot.Type = GetTypeFromString(val["Type"].GetString());
-            }
-            else
-            {
-                std::cerr << "Unable to parse type for bot " << NewBot.BotName << std::endl;
-                continue;
-            }
-            if (NewBot.Type != DefaultBot)
-            {
-                if (val.HasMember("RootPath") && val["RootPath"].IsString())
-                {
-                    NewBot.RootPath = val["RootPath"].GetString();
-                    if (NewBot.RootPath.back() != '/')
-                    {
-                        NewBot.RootPath += '/';
-                    }
-                }
-                else
-                {
-                    std::cerr << "Unable to parse root path for bot " << NewBot.BotName << std::endl;
-                    continue;
-                }
-                if (val.HasMember("FileName") && val["FileName"].IsString())
-                {
-                    NewBot.FileName = val["FileName"].GetString();
-                }
-                else
-                {
-                    std::cerr << "Unable to parse file name for bot " << NewBot.BotName << std::endl;
-                    continue;
-                }
-                if (!sc2::DoesFileExist(NewBot.RootPath + NewBot.FileName))
-                {
-                    std::cerr << "Unable to parse bot " << NewBot.BotName << std::endl;
-                    std::cerr << "Is the path " << NewBot.RootPath << "correct?" << std::endl;
-                    continue;
-                }
-                if (val.HasMember("Args") && val["Args"].IsString())
-                {
-                    NewBot.Args = val["Arg"].GetString();
-                }
-                if (val.HasMember("Debug") && val["Debug"].IsBool()) {
-                    NewBot.Debug = val["Debug"].GetBool();
-                }
-            }
-            else
-            {
-                if (val.HasMember("Difficulty") && val["Difficulty"].IsString())
-                {
-                    NewBot.Difficulty = GetDifficultyFromString(val["Difficulty"].GetString());
-                }
-            }
-            if (EnablePlayerIds)
-            {
-                NewBot.PlayerId = PlayerIds->GetValue(NewBot.BotName);
-                if (NewBot.PlayerId.empty())
-                {
-                    NewBot.PlayerId = GerneratePlayerId(PLAYER_ID_LENGTH);
-                    PlayerIds->AddValue(NewBot.BotName, NewBot.PlayerId);
-                    PlayerIds->WriteConfig();
-                }
-            }
-            BotConfigs.insert(std::make_pair(std::string(NewBot.BotName), NewBot));
+			if (val.HasMember("Race") && val["Race"].IsString())
+			{
+				NewBot.Race = GetRaceFromString(val["Race"].GetString());
+			}
+			else
+			{
+				std::cerr << "Unable to parse race for bot " << NewBot.BotName << std::endl;
+				continue;
+			}
+			if (val.HasMember("Type") && val["Type"].IsString())
+			{
+				NewBot.Type = GetTypeFromString(val["Type"].GetString());
+			}
+			else
+			{
+				std::cerr << "Unable to parse type for bot " << NewBot.BotName << std::endl;
+				continue;
+			}
+			if (NewBot.Type != DefaultBot)
+			{
+				if (val.HasMember("RootPath") && val["RootPath"].IsString())
+				{
+					NewBot.RootPath = val["RootPath"].GetString();
+					if (NewBot.RootPath.back() != '/')
+					{
+						NewBot.RootPath += '/';
+					}
+				}
+				else
+				{
+					std::cerr << "Unable to parse root path for bot " << NewBot.BotName << std::endl;
+					continue;
+				}
+				if (val.HasMember("FileName") && val["FileName"].IsString())
+				{
+					NewBot.FileName = val["FileName"].GetString();
+				}
+				else
+				{
+					std::cerr << "Unable to parse file name for bot " << NewBot.BotName << std::endl;
+					continue;
+				}
+				if (!sc2::DoesFileExist(NewBot.RootPath + NewBot.FileName))
+				{
+					std::cerr << "Unable to parse bot " << NewBot.BotName << std::endl;
+					std::cerr << "Is the path " << NewBot.RootPath << "correct?" << std::endl;
+					continue;
+				}
+				if (val.HasMember("Args") && val["Args"].IsString())
+				{
+					NewBot.Args = val["Arg"].GetString();
+				}
+				if (val.HasMember("Debug") && val["Debug"].IsBool()) {
+					NewBot.Debug = val["Debug"].GetBool();
+				}
+			}
+			else
+			{
+				if (val.HasMember("Difficulty") && val["Difficulty"].IsString())
+				{
+					NewBot.Difficulty = GetDifficultyFromString(val["Difficulty"].GetString());
+				}
+			}
+			if (EnablePlayerIds)
+			{
+				NewBot.PlayerId = PlayerIds->GetValue(NewBot.BotName);
+				if (NewBot.PlayerId.empty())
+				{
+					NewBot.PlayerId = GerneratePlayerId(PLAYER_ID_LENGTH);
+					PlayerIds->AddValue(NewBot.BotName, NewBot.PlayerId);
+					PlayerIds->WriteConfig();
+				}
+			}
+			BotConfigs.insert(std::make_pair(std::string(NewBot.BotName), NewBot));
 
-        }
-    }
-    if (doc.HasMember("Maps") && doc["Maps"].IsArray())
-    {
-        const rapidjson::Value & Maps = doc["Maps"];
-        for (auto itr = Maps.Begin(); itr != Maps.End(); ++itr)
-        {
-            MapList.push_back(itr->GetString());
-        }
-    }
+		}
+	}
+	if (doc.HasMember("Maps") && doc["Maps"].IsArray())
+	{
+		const rapidjson::Value & Maps = doc["Maps"];
+		for (auto itr = Maps.Begin(); itr != Maps.End(); ++itr)
+		{
+			MapList.push_back(itr->GetString());
+		}
+	}
 }
 
 std::string LadderManager::RemoveMapExtension(const std::string& filename) {
-    size_t lastdot = filename.find_last_of(".");
-    if (lastdot == std::string::npos) return filename;
-    return filename.substr(0, lastdot);
+	size_t lastdot = filename.find_last_of(".");
+	if (lastdot == std::string::npos) return filename;
+	return filename.substr(0, lastdot);
 }
 
 void LadderManager::ChangeBotNames(const std::string ReplayFile, const std::string &Bot1Name, const std::string Bot2Name)
 {
-    std::string CmdLine = Config->GetValue("ReplayBotRenameProgram");
-    if (CmdLine.size() > 0)
-    {
-        CmdLine = CmdLine + " " + ReplayFile + " " + FIRST_PLAYER_NAME + " " + Bot1Name + " " + SECOND_PLAYER_NAME + " " + Bot2Name;
-        StartExternalProcess(CmdLine);
-    }
+	std::string CmdLine = Config->GetValue("ReplayBotRenameProgram");
+	if (CmdLine.size() > 0)
+	{
+		CmdLine = CmdLine + " " + ReplayFile + " " + FIRST_PLAYER_NAME + " " + Bot1Name + " " + SECOND_PLAYER_NAME + " " + Bot2Name;
+		StartExternalProcess(CmdLine);
+	}
 }
 
 bool LadderManager::UploadCmdLine(GameResult result, const Matchup &ThisMatch)
 {
-    std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
-    std::string UploadResultLocation = Config->GetValue("UploadResultLocation");
-    std::string RawMapName = RemoveMapExtension(ThisMatch.Map);
-    std::string ReplayFile;
-    if (ThisMatch.Agent2.Type == BotType::DefaultBot)
-    {
-        ReplayFile = ThisMatch.Agent1.BotName + "v" + GetDifficultyString(ThisMatch.Agent2.Difficulty) + "-" + RawMapName + ".Sc2Replay";
-    }
-    else
-    {
-        ReplayFile = ThisMatch.Agent1.BotName + "v" + ThisMatch.Agent2.BotName + "-" + RawMapName + ".Sc2Replay";
-    }
-    ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
-    std::string ReplayLoc = ReplayDir + ReplayFile;
+	std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
+	std::string UploadResultLocation = Config->GetValue("UploadResultLocation");
+	std::string RawMapName = RemoveMapExtension(ThisMatch.Map);
+	std::string ReplayFile;
+	if (ThisMatch.Agent2.Type == BotType::DefaultBot)
+	{
+		ReplayFile = ThisMatch.Agent1.BotName + "v" + GetDifficultyString(ThisMatch.Agent2.Difficulty) + "-" + RawMapName + ".Sc2Replay";
+	}
+	else
+	{
+		ReplayFile = ThisMatch.Agent1.BotName + "v" + ThisMatch.Agent2.BotName + "-" + RawMapName + ".Sc2Replay";
+	}
+	ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
+	std::string ReplayLoc = ReplayDir + ReplayFile;
 
-    std::string CurlCmd = "curl";
-    CurlCmd = CurlCmd + " -F Bot1Name=" + ThisMatch.Agent1.BotName;
-    CurlCmd = CurlCmd + " -F Bot1Race=" + std::to_string((int)ThisMatch.Agent1.Race);
-    CurlCmd = CurlCmd + " -F Bot2Name=" + ThisMatch.Agent2.BotName;
-    CurlCmd = CurlCmd + " -F Bot2Race=" + std::to_string((int)ThisMatch.Agent2.Race);
-    CurlCmd = CurlCmd + " -F Bot1AvgFrame=" + std::to_string(result.Bot1AvgFrame);
-    CurlCmd = CurlCmd + " -F Bot2AvgFrame=" + std::to_string(result.Bot2AvgFrame);
-    CurlCmd = CurlCmd + " -F Frames=" + std::to_string(result.GameLoop);
-    CurlCmd = CurlCmd + " -F Map=" + RawMapName;
-    CurlCmd = CurlCmd + " -F Result=" + GetResultType(result.Result);
-    CurlCmd = CurlCmd + " -F replayfile=@" + ReplayLoc;
-    CurlCmd = CurlCmd + " " + UploadResultLocation;
-    StartExternalProcess(CurlCmd);
-    return true;
+	std::string CurlCmd = "curl";
+	CurlCmd = CurlCmd + " -F Bot1Name=" + ThisMatch.Agent1.BotName;
+	CurlCmd = CurlCmd + " -F Bot1Race=" + std::to_string((int)ThisMatch.Agent1.Race);
+	CurlCmd = CurlCmd + " -F Bot2Name=" + ThisMatch.Agent2.BotName;
+	CurlCmd = CurlCmd + " -F Bot2Race=" + std::to_string((int)ThisMatch.Agent2.Race);
+	CurlCmd = CurlCmd + " -F Bot1AvgFrame=" + std::to_string(result.Bot1AvgFrame);
+	CurlCmd = CurlCmd + " -F Bot2AvgFrame=" + std::to_string(result.Bot2AvgFrame);
+	CurlCmd = CurlCmd + " -F Frames=" + std::to_string(result.GameLoop);
+	CurlCmd = CurlCmd + " -F Map=" + RawMapName;
+	CurlCmd = CurlCmd + " -F Result=" + GetResultType(result.Result);
+	CurlCmd = CurlCmd + " -F replayfile=@" + ReplayLoc;
+	CurlCmd = CurlCmd + " " + UploadResultLocation;
+	StartExternalProcess(CurlCmd);
+	return true;
 }
 
 
 bool LadderManager::LoginToServer()
 {
-    std::cout << "LoginToServer feature has been temporarily disabled";
-    return false;
+	std::cout << "LoginToServer feature has been temporarily disabled";
+	return false;
 }
 
 bool LadderManager::CheckDiactivatedBots() {
-    if (BotCheckLocation.empty())
-    {
-        return false;
-    }
-    std::string result = PerformRestRequest(BotCheckLocation);
-    if (result.empty())
-    {
-        return false;
-    }
-    rapidjson::Document doc;
-    bool parsingFailed = doc.Parse(result.c_str()).HasParseError();
-    if (parsingFailed)
-    {
-        std::cerr << "Unable to parse incoming bot config: " << ConfigFile << std::endl;
-        return false;
-    }
-    if (doc.HasMember("Bots") && doc["Bots"].IsArray())
-    {
-        const rapidjson::Value & Units = doc["Bots"];
-        for (const auto& val : Units.GetArray())
-        {
-            if (val.HasMember("name") && val["name"].IsString())
-            {
-                auto ThisBot = BotConfigs.find(val["name"].GetString());
-                if (ThisBot != BotConfigs.end())
-                {
-                    if (val.HasMember("deactivated") && val.HasMember("deleted") && val["deactivated"].IsBool() && val["deleted"].IsBool())
-                    {
-                        if ((val["deactivated"].GetBool() || val["deleted"].GetBool()) && ThisBot->second.Enabled)
-                        {
-                            // Set bot to disabled
-                            PrintThread{} << "Deactivating bot " << ThisBot->second.BotName << std::endl;
-                            ThisBot->second.Enabled = false;
+	if (BotCheckLocation.empty())
+	{
+		return false;
+	}
+	std::string result = PerformRestRequest(BotCheckLocation);
+	if (result.empty())
+	{
+		return false;
+	}
+	rapidjson::Document doc;
+	bool parsingFailed = doc.Parse(result.c_str()).HasParseError();
+	if (parsingFailed)
+	{
+		std::cerr << "Unable to parse incoming bot config: " << ConfigFile << std::endl;
+		return false;
+	}
+	if (doc.HasMember("Bots") && doc["Bots"].IsArray())
+	{
+		const rapidjson::Value & Units = doc["Bots"];
+		for (const auto& val : Units.GetArray())
+		{
+			if (val.HasMember("name") && val["name"].IsString())
+			{
+				auto ThisBot = BotConfigs.find(val["name"].GetString());
+				if (ThisBot != BotConfigs.end())
+				{
+					if (val.HasMember("deactivated") && val.HasMember("deleted") && val["deactivated"].IsBool() && val["deleted"].IsBool())
+					{
+						if ((val["deactivated"].GetBool() || val["deleted"].GetBool()) && ThisBot->second.Enabled)
+						{
+							// Set bot to disabled
+							PrintThread{} << "Deactivating bot " << ThisBot->second.BotName << std::endl;
+							ThisBot->second.Enabled = false;
 
-                        }
-                        else if (val["deactivated"].GetBool() == false && val["deleted"].GetBool() == false && ThisBot->second.Enabled == false)
-                        {
-                            // reenable a bot
-                            PrintThread{} << "Activating bot " << ThisBot->second.BotName;
-                            ThisBot->second.Enabled = true;
-                        }
-                    }
-                    if (val.HasMember("elo") && val["elo"].IsString())
-                    {
-                        ThisBot->second.ELO = std::stoi(val["elo"].GetString());
-                    }
-                }
+						}
+						else if (val["deactivated"].GetBool() == false && val["deleted"].GetBool() == false && ThisBot->second.Enabled == false)
+						{
+							// reenable a bot
+							PrintThread{} << "Activating bot " << ThisBot->second.BotName;
+							ThisBot->second.Enabled = true;
+						}
+					}
+					if (val.HasMember("elo") && val["elo"].IsString())
+					{
+						ThisBot->second.ELO = std::stoi(val["elo"].GetString());
+					}
+				}
 
-            }
-        }
-        return true;
-    }
-    return false;
+			}
+		}
+		return true;
+	}
+	return false;
 }
 
 bool LadderManager::IsBotEnabled(std::string BotName)
 {
-    auto ThisBot = BotConfigs.find(BotName);
-    if (ThisBot != BotConfigs.end())
-    {
-        return ThisBot->second.Enabled;
-    }
-    return false;
+	auto ThisBot = BotConfigs.find(BotName);
+	if (ThisBot != BotConfigs.end())
+	{
+		return ThisBot->second.Enabled;
+	}
+	return false;
 }
 bool LadderManager::IsInsideEloRange(std::string Bot1Name, std::string Bot2Name)
 {
-    if (MaxEloDiff == 0)
-    {
-        return true;
-    }
-    auto Bot1 = BotConfigs.find(Bot1Name);
-    auto Bot2 = BotConfigs.find(Bot2Name);
-    if(Bot1 != BotConfigs.end() && Bot2 != BotConfigs.end())
-    {
-        int32_t EloDiff = abs(Bot1->second.ELO - Bot2->second.ELO);
-        PrintThread{} << Bot1Name << " ELO: " << Bot1->second.ELO << " | " << Bot2Name << " ELO: " << Bot2->second.ELO << " | Diff: " << EloDiff << std::endl;
+	if (MaxEloDiff == 0)
+	{
+		return true;
+	}
+	auto Bot1 = BotConfigs.find(Bot1Name);
+	auto Bot2 = BotConfigs.find(Bot2Name);
+	if(Bot1 != BotConfigs.end() && Bot2 != BotConfigs.end())
+	{
+		int32_t EloDiff = abs(Bot1->second.ELO - Bot2->second.ELO);
+		PrintThread{} << Bot1Name << " ELO: " << Bot1->second.ELO << " | " << Bot2Name << " ELO: " << Bot2->second.ELO << " | Diff: " << EloDiff << std::endl;
 
-        if (Bot1->second.ELO > 0 && Bot2->second.ELO > 0 && abs(EloDiff) > MaxEloDiff)
-        {
-            return false;
-        }
-        return true;
-    }
-    return true;
+		if (Bot1->second.ELO > 0 && Bot2->second.ELO > 0 && abs(EloDiff) > MaxEloDiff)
+		{
+			return false;
+		}
+		return true;
+	}
+	return true;
 }
 
 void LadderManager::RunLadderManager()
 {
 
-    LoadAgents();
-    PrintThread{} << "Starting with " << MapList.size() << " maps:" << std::endl;
-    for (auto &map : MapList)
-    {
-        PrintThread{} << "* " << map << std::endl;
-    }
-    PrintThread{} << "Starting with agents: " << std::endl;
-    for (auto &Agent : BotConfigs)
-    {
-        PrintThread{} << Agent.second.BotName << std::endl;
-    }
-    std::string MatchListFile = Config->GetValue("MatchupListFile");
-    MatchupList *Matchups = new MatchupList(MatchListFile);
-    Matchups->GenerateMatches(BotConfigs, MapList);
-    Matchup NextMatch;
-    try
-    {
-        if (EnableServerLogin)
-        {
-            LoginToServer();
-        }
-        CheckDiactivatedBots();
-        while (Matchups->GetNextMatchup(NextMatch))
-        {
+	LoadAgents();
+	PrintThread{} << "Starting with " << MapList.size() << " maps:" << std::endl;
+	for (auto &map : MapList)
+	{
+		PrintThread{} << "* " << map << std::endl;
+	}
+	PrintThread{} << "Starting with agents: " << std::endl;
+	for (auto &Agent : BotConfigs)
+	{
+		PrintThread{} << Agent.second.BotName << std::endl;
+	}
+	std::string MatchListFile = Config->GetValue("MatchupListFile");
+	MatchupList *Matchups = new MatchupList(MatchListFile);
+	Matchups->GenerateMatches(BotConfigs, MapList);
+	Matchup NextMatch;
+	try
+	{
+		if (EnableServerLogin)
+		{
+			LoginToServer();
+		}
+		CheckDiactivatedBots();
+		while (Matchups->GetNextMatchup(NextMatch))
+		{
 
-            if (IsBotEnabled(NextMatch.Agent1.BotName) && IsBotEnabled(NextMatch.Agent2.BotName) && IsInsideEloRange(NextMatch.Agent1.BotName, NextMatch.Agent2.BotName))
-            {
-                GameResult result;
-                PrintThread{} << std::endl << "Starting " << NextMatch.Agent1.BotName << " vs " << NextMatch.Agent2.BotName << " on " << NextMatch.Map << std::endl;
-                if (NextMatch.Agent1.Type == DefaultBot || NextMatch.Agent2.Type == DefaultBot)
-                {
-                    if (NextMatch.Agent1.Type == DefaultBot)
-                    {
-                        // Swap so computer is always player 2
-                        BotConfig Temp = NextMatch.Agent1;
-                        NextMatch.Agent1 = NextMatch.Agent2;
-                        NextMatch.Agent2 = Temp;
-                    }
-                    result = StartGameVsDefault(NextMatch.Agent1, NextMatch.Agent2.Race, NextMatch.Agent2.Difficulty, NextMatch.Map);
-                }
-                else
-                {
-                    result = StartGame(NextMatch.Agent1, NextMatch.Agent2, NextMatch.Map);
-                }
-                PrintThread{} << std::endl << "Game finished with result: " << GetResultType(result.Result) << std::endl;
-                if (EnableReplayUploads)
-                {
-                    UploadCmdLine(result, NextMatch);
-                }
-                if (ResultsLogFile.size() > 0)
-                {
-                    SaveJsonResult(NextMatch.Agent1, NextMatch.Agent2, NextMatch.Map, result);
-                }
-                Matchups->SaveMatchList();
-            }
-        }
-    }
-    catch (const std::exception& e)
-    {
-        PrintThread{} << "Exception in game " << e.what() << std::endl;
-        SaveError(NextMatch.Agent1.BotName, NextMatch.Agent2.BotName, NextMatch.Map);
-    }
+			if (IsBotEnabled(NextMatch.Agent1.BotName) && IsBotEnabled(NextMatch.Agent2.BotName) && IsInsideEloRange(NextMatch.Agent1.BotName, NextMatch.Agent2.BotName))
+			{
+				GameResult result;
+				PrintThread{} << std::endl << "Starting " << NextMatch.Agent1.BotName << " vs " << NextMatch.Agent2.BotName << " on " << NextMatch.Map << std::endl;
+				if (NextMatch.Agent1.Type == DefaultBot || NextMatch.Agent2.Type == DefaultBot)
+				{
+					if (NextMatch.Agent1.Type == DefaultBot)
+					{
+						// Swap so computer is always player 2
+						BotConfig Temp = NextMatch.Agent1;
+						NextMatch.Agent1 = NextMatch.Agent2;
+						NextMatch.Agent2 = Temp;
+					}
+					result = StartGameVsDefault(NextMatch.Agent1, NextMatch.Agent2.Race, NextMatch.Agent2.Difficulty, NextMatch.Map);
+				}
+				else
+				{
+					result = StartGame(NextMatch.Agent1, NextMatch.Agent2, NextMatch.Map);
+				}
+				PrintThread{} << std::endl << "Game finished with result: " << GetResultType(result.Result) << std::endl;
+				if (EnableReplayUploads)
+				{
+					UploadCmdLine(result, NextMatch);
+				}
+				if (ResultsLogFile.size() > 0)
+				{
+					SaveJsonResult(NextMatch.Agent1, NextMatch.Agent2, NextMatch.Map, result);
+				}
+				Matchups->SaveMatchList();
+			}
+		}
+	}
+	catch (const std::exception& e)
+	{
+		PrintThread{} << "Exception in game " << e.what() << std::endl;
+		SaveError(NextMatch.Agent1.BotName, NextMatch.Agent2.BotName, NextMatch.Map);
+	}
 
 }
 
 void LadderManager::SaveError(const std::string &Agent1, const std::string &Agent2, const std::string &Map)
 {
-    std::string ErrorListFile = Config->GetValue("ErrorListFile");
-    if (ErrorListFile == "")
-    {
-        return;
-    }
-    std::ofstream ofs(ErrorListFile, std::ofstream::app);
-    if (!ofs)
-    {
-        return;
-    }
-    ofs << "\"" + Agent1 + "\"vs\"" + Agent2 + "\" " + Map << std::endl;
-    ofs.close();
+	std::string ErrorListFile = Config->GetValue("ErrorListFile");
+	if (ErrorListFile == "")
+	{
+		return;
+	}
+	std::ofstream ofs(ErrorListFile, std::ofstream::app);
+	if (!ofs)
+	{
+		return;
+	}
+	ofs << "\"" + Agent1 + "\"vs\"" + Agent2 + "\" " + Map << std::endl;
+	ofs.close();
 }

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -45,1314 +45,1405 @@ std::mutex PrintThread::_mutexPrint{};
 
 bool ProcessResponse(const SC2APIProtocol::ResponseCreateGame& response)
 {
-	bool success = true;
-	if (response.has_error()) {
-		std::string errorCode = "Unknown";
-		switch (response.error()) {
-		case SC2APIProtocol::ResponseCreateGame::MissingMap: {
-			errorCode = "Missing Map";
-			break;
-		}
-		case SC2APIProtocol::ResponseCreateGame::InvalidMapPath: {
-			errorCode = "Invalid Map Path";
-			break;
-		}
-		case SC2APIProtocol::ResponseCreateGame::InvalidMapData: {
-			errorCode = "Invalid Map Data";
-			break;
-		}
-		case SC2APIProtocol::ResponseCreateGame::InvalidMapName: {
-			errorCode = "Invalid Map Name";
-			break;
-		}
-		case SC2APIProtocol::ResponseCreateGame::InvalidMapHandle: {
-			errorCode = "Invalid Map Handle";
-			break;
-		}
-		case SC2APIProtocol::ResponseCreateGame::MissingPlayerSetup: {
-			errorCode = "Missing Player Setup";
-			break;
-		}
-		case SC2APIProtocol::ResponseCreateGame::InvalidPlayerSetup: {
-			errorCode = "Invalid Player Setup";
-			break;
-		}
-		default: {
-			break;
-		}
-		}
+    bool success = true;
+    if (response.has_error()) {
+        std::string errorCode = "Unknown";
+        switch (response.error()) {
+        case SC2APIProtocol::ResponseCreateGame::MissingMap: {
+            errorCode = "Missing Map";
+            break;
+        }
+        case SC2APIProtocol::ResponseCreateGame::InvalidMapPath: {
+            errorCode = "Invalid Map Path";
+            break;
+        }
+        case SC2APIProtocol::ResponseCreateGame::InvalidMapData: {
+            errorCode = "Invalid Map Data";
+            break;
+        }
+        case SC2APIProtocol::ResponseCreateGame::InvalidMapName: {
+            errorCode = "Invalid Map Name";
+            break;
+        }
+        case SC2APIProtocol::ResponseCreateGame::InvalidMapHandle: {
+            errorCode = "Invalid Map Handle";
+            break;
+        }
+        case SC2APIProtocol::ResponseCreateGame::MissingPlayerSetup: {
+            errorCode = "Missing Player Setup";
+            break;
+        }
+        case SC2APIProtocol::ResponseCreateGame::InvalidPlayerSetup: {
+            errorCode = "Invalid Player Setup";
+            break;
+        }
+        default: {
+            break;
+        }
+        }
 
-		std::cerr << "CreateGame request returned an error code: " << errorCode << std::endl;
-		success = false;
-	}
+        std::cerr << "CreateGame request returned an error code: " << errorCode << std::endl;
+        success = false;
+    }
 
-	if (response.has_error_details() && response.error_details().length() > 0) {
-		std::cerr << "CreateGame request returned error details: " << response.error_details() << std::endl;
-		success = false;
-	}
-	return success;
+    if (response.has_error_details() && response.error_details().length() > 0) {
+        std::cerr << "CreateGame request returned error details: " << response.error_details() << std::endl;
+        success = false;
+    }
+    return success;
 
 }
 
+std::mutex m;
+bool gameEnded = false;
 
+void setGameEnded(const bool status)
+{
+    std::lock_guard<std::mutex> lock(m);
+    gameEnded = status;
+}
+
+bool getGameEnded()
+{
+    std::lock_guard<std::mutex> lock(m);
+    return gameEnded;
+}
 
 ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server, const std::string *botName, uint32_t MaxGameTime, uint32_t MaxRealGameTime, float_t *AvgFrame, int32_t *GameLoop)
 {
-	//    std::cout << "Sending Join game request" << std::endl;
-	//    sc2::GameRequestPtr Create_game_request = CreateJoinGameRequest();
-	//    Client->Send(Create_game_request.get());
-	ExitCase CurrentExitCase = ExitCase::InProgress;
-	PrintThread{} << "Starting proxy for " << *botName << std::endl;
-	clock_t LastRequest = clock();
-	clock_t FirstRequest = clock();
-	clock_t StepTime = 0;
-	uint32_t currentGameLoop = 0;
-	float_t totalTime = 0;
-	float_t AvgStepTime = 0;
-	std::map<SC2APIProtocol::Status, std::string> status;
-	status[SC2APIProtocol::Status::launched] = "launched";
-	status[SC2APIProtocol::Status::init_game] = "init_game";
-	status[SC2APIProtocol::Status::in_game] = "in_game";
-	status[SC2APIProtocol::Status::in_replay] = "in_replay";
-	status[SC2APIProtocol::Status::ended] = "ended";
-	status[SC2APIProtocol::Status::quit] = "quit";
-	status[SC2APIProtocol::Status::unknown] = "unknown";
-	SC2APIProtocol::Status OldStatus = SC2APIProtocol::Status::unknown;
-	try
-	{
-		bool RequestFound = false;
-		bool AlreadyWarned = false;
-		while (CurrentExitCase == ExitCase::InProgress) {
-			SC2APIProtocol::Status CurrentStatus;
-			if (!client || !server)
-			{
-				PrintThread{} << botName << " Null server or client returning ClientTimeout" << std::endl;
-				return ExitCase::ClientTimeout;
-			}
-			if (client->connection_ == nullptr && RequestFound)
-			{
-				PrintThread{} << "Client disconnect (" << *botName << ")" << std::endl;
-				CurrentExitCase = ExitCase::ClientTimeout;
-			}
+    ExitCase CurrentExitCase = ExitCase::InProgress;
+    PrintThread{} << "Starting proxy for " << *botName << std::endl;
+    setGameEnded(false);
+    clock_t LastRequest = clock();
+    clock_t FirstRequest = clock();
+    clock_t StepTime = 0;
+    uint32_t currentGameLoop = 0;
+    float_t totalTime = 0;
+    float_t AvgStepTime = 0;
+    std::map<SC2APIProtocol::Status, std::string> status;
+    status[SC2APIProtocol::Status::launched] = "launched";
+    status[SC2APIProtocol::Status::init_game] = "init_game";
+    status[SC2APIProtocol::Status::in_game] = "in_game";
+    status[SC2APIProtocol::Status::in_replay] = "in_replay";
+    status[SC2APIProtocol::Status::ended] = "ended";
+    status[SC2APIProtocol::Status::quit] = "quit";
+    status[SC2APIProtocol::Status::unknown] = "unknown";
+    SC2APIProtocol::Status OldStatus = SC2APIProtocol::Status::unknown;
+    try
+    {
+        bool RequestFound = false;
+        bool AlreadyWarned = false;
+        while (CurrentExitCase == ExitCase::InProgress && !getGameEnded()) {
+            SC2APIProtocol::Status CurrentStatus;
+            if (!client || !server)
+            {
+                PrintThread{} << botName << " Null server or client returning ClientTimeout" << std::endl;
+                return ExitCase::ClientTimeout;
+            }
+            if (client->connection_ == nullptr && RequestFound)
+            {
+                PrintThread{} << "Client disconnect (" << *botName << ")" << std::endl;
+                CurrentExitCase = ExitCase::ClientTimeout;
+            }
 
-			if (server->HasRequest())
-			{
-				const sc2::RequestData request = server->PeekRequest();
-				if (request.second)
-				{
-					if (request.second->has_quit()) //Really paranoid here...
-					{
-						// Intercept leave game and quit requests, we want to keep game alive to save replays
-						CurrentExitCase = ExitCase::ClientRequestExit;
-						break;
-					}
-					else if (request.second->has_debug() && !AlreadyWarned)
-					{
-						PrintThread{} << *botName << " IS USING DEBUG INTERFACE.  POSSIBLE CHEAT Please tell them not to" << std::endl;
-						AlreadyWarned = true;
-					}
-					else if (StepTime > 0 && request.second->has_step())
-					{
-						clock_t ThisStepTime = clock() - StepTime;
-						totalTime += static_cast<float_t>(ThisStepTime);
-						AvgStepTime = totalTime/static_cast<float_t>(currentGameLoop);
-					}
-				}
-				if (client->connection_ != nullptr)
-				{
-					server->SendRequest(client->connection_);
+            if (server->HasRequest())
+            {
+                const sc2::RequestData request = server->PeekRequest();
+                if (request.second)
+                {
+                    if (request.second->has_quit()) //Really paranoid here...
+                    {
+                        // Intercept leave game and quit requests, we want to keep game alive to save replays
+                        CurrentExitCase = ExitCase::ClientRequestExit;
+                        break;
+                    }
+                    else if (request.second->has_debug() && !AlreadyWarned)
+                    {
+                        PrintThread{} << *botName << " IS USING DEBUG INTERFACE.  POSSIBLE CHEAT Please tell them not to" << std::endl;
+                        AlreadyWarned = true;
+                    }
+                    else if (StepTime > 0 && request.second->has_step())
+                    {
+                        clock_t ThisStepTime = clock() - StepTime;
+                        totalTime += static_cast<float_t>(ThisStepTime);
+                        AvgStepTime = totalTime/static_cast<float_t>(currentGameLoop);
+                    }
+                }
+                if (client->connection_ != nullptr)
+                {
+                    server->SendRequest(client->connection_);
 
-				}
+                }
 
-				// Block for sc2's response then queue it.
-				SC2APIProtocol::Response* response = nullptr;
-				client->Receive(response, 100000);
-				if (response != nullptr)
-				{
-					CurrentStatus = response->status();
-					if (OldStatus != CurrentStatus)
-					{
-						PrintThread{} << "New status of " << *botName << ": " << status.at(CurrentStatus) << std::endl;
-						OldStatus = CurrentStatus;
-					}
-					if (CurrentStatus > SC2APIProtocol::Status::in_replay)
-					{
-						CurrentExitCase = ExitCase::GameEnd;
-					}
-					if (response->has_observation())
-					{
-						const SC2APIProtocol::ResponseObservation LastObservation = response->observation();
-						const SC2APIProtocol::Observation& ActualObservation = LastObservation.observation();
-						currentGameLoop = ActualObservation.game_loop();
-						if (currentGameLoop > MaxGameTime)
-						{
-							CurrentExitCase = ExitCase::GameTimeout;
-						}
-						if (GameLoop != nullptr)
-						{
-							*GameLoop = currentGameLoop;
-						}
-					}
-					else if (response->has_step())
-					{
-						StepTime = clock();
-					}
-					if (MaxRealGameTime > 0)
-					{
-						if (clock() > (FirstRequest + (MaxRealGameTime * CLOCKS_PER_SEC)))
-						{
-							CurrentExitCase = ExitCase::GameTimeout;
-						}
-					}
+                // Block for sc2's response then queue it.
+                SC2APIProtocol::Response* response = nullptr;
+                client->Receive(response, 100000);
+                if (response != nullptr)
+                {
+                    CurrentStatus = response->status();
+                    if (OldStatus != CurrentStatus)
+                    {
+                        PrintThread{} << "New status of " << *botName << ": " << status.at(CurrentStatus) << std::endl;
+                        OldStatus = CurrentStatus;
+                    }
+                    if (CurrentStatus > SC2APIProtocol::Status::in_replay)
+                    {
+                        CurrentExitCase = ExitCase::GameEnd;
+                    }
+                    if (response->has_observation())
+                    {
+                        const SC2APIProtocol::ResponseObservation LastObservation = response->observation();
+                        const SC2APIProtocol::Observation& ActualObservation = LastObservation.observation();
+                        currentGameLoop = ActualObservation.game_loop();
+                        if (currentGameLoop > MaxGameTime)
+                        {
+                            CurrentExitCase = ExitCase::GameTimeout;
+                        }
+                        if (GameLoop != nullptr)
+                        {
+                            *GameLoop = currentGameLoop;
+                        }
+                    }
+                    else if (response->has_step())
+                    {
+                        StepTime = clock();
+                    }
+                    if (MaxRealGameTime > 0)
+                    {
+                        if (clock() > (FirstRequest + (MaxRealGameTime * CLOCKS_PER_SEC)))
+                        {
+                            CurrentExitCase = ExitCase::GameTimeout;
+                        }
+                    }
 
-				}
+                }
 
-				// Send the response back to the client.
-				if (server->connections_.size() > 0 && client->connection_ != NULL)
-				{
-					server->QueueResponse(client->connection_, response);
-					server->SendResponse();
-				}
-				else
-				{
-					CurrentExitCase = ExitCase::ClientTimeout;
-				}
-				LastRequest = clock();
+                // Send the response back to the client.
+                if (server->connections_.size() > 0 && client->connection_ != NULL)
+                {
+                    server->QueueResponse(client->connection_, response);
+                    server->SendResponse();
+                }
+                else
+                {
+                    CurrentExitCase = ExitCase::ClientTimeout;
+                }
+                LastRequest = clock();
 
-			}
-			else
-			{
-				if ((LastRequest + (50 * CLOCKS_PER_SEC)) < clock())
-				{
-					PrintThread{} << "Client timeout (" << *botName <<")" << std::endl;
-					CurrentExitCase = ExitCase::ClientTimeout;
-				}
-			}
-		}
-		*AvgFrame = AvgStepTime;
-		PrintThread{} << *botName << " Exiting with " << GetExitCaseString(CurrentExitCase) << " Average step time " << AvgStepTime << std::endl;
-		return CurrentExitCase;
-	}
-	catch (const std::exception& e)
-	{
-		PrintThread{} << e.what() << std::endl;
-		return ExitCase::ClientTimeout;
-	}
+            }
+            else
+            {
+                if ((LastRequest + (50 * CLOCKS_PER_SEC)) < clock())
+                {
+                    PrintThread{} << "Client timeout (" << *botName <<")" << std::endl;
+                    CurrentExitCase = ExitCase::ClientTimeout;
+                }
+            }
+        }
+        *AvgFrame = AvgStepTime;
+        PrintThread{} << *botName << " Exiting with " << GetExitCaseString(CurrentExitCase) << " Average step time " << AvgStepTime << ", total time: " << totalTime << ", game loops: " << currentGameLoop << std::endl;
+        setGameEnded(true);
+        return CurrentExitCase;
+    }
+    catch (const std::exception& e)
+    {
+        PrintThread{} << e.what() << std::endl;
+        return ExitCase::ClientTimeout;
+    }
+}
+
+ExitCase OnEnd(sc2::Connection *client, sc2::Server *server, const std::string *botName)
+{
+    ExitCase CurrentExitCase = ExitCase::InProgress;
+    PrintThread{} << "Processing last requests/responses for " << *botName << std::endl;
+    std::time_t LastRequest = std::time(nullptr);
+    std::map<SC2APIProtocol::Status, std::string> status;
+    status[SC2APIProtocol::Status::launched] = "launched";
+    status[SC2APIProtocol::Status::init_game] = "init_game";
+    status[SC2APIProtocol::Status::in_game] = "in_game";
+    status[SC2APIProtocol::Status::in_replay] = "in_replay";
+    status[SC2APIProtocol::Status::ended] = "ended";
+    status[SC2APIProtocol::Status::quit] = "quit";
+    status[SC2APIProtocol::Status::unknown] = "unknown";
+    SC2APIProtocol::Status OldStatus = SC2APIProtocol::Status::in_game;
+    try
+    {
+        while (CurrentExitCase == ExitCase::InProgress)
+        {
+            SC2APIProtocol::Status CurrentStatus;
+            if (!client || !server)
+            {
+                PrintThread{} << *botName << " Null server or client returning ClientTimeout" << std::endl;
+                return ExitCase::ClientTimeout;
+            }
+            if (client->connection_ == nullptr)
+            {
+                PrintThread{} << "Client disconnect (" << *botName << ")" << std::endl;
+                CurrentExitCase = ExitCase::ClientTimeout;
+            }
+            if (server->HasRequest())
+            {
+                if (client->connection_ != nullptr)
+                {
+                    PrintThread{} << "Sending request of " << *botName << std::endl;
+                    server->SendRequest(client->connection_);
+                    LastRequest = std::time(nullptr);
+                }
+            }
+            SC2APIProtocol::Response* response = nullptr;
+            if (client->Receive(response, 1000)) // why is server->hasResponse() not working?!
+            {
+                // Send the response back to the client.
+                if (response && server->connections_.size() > 0 && client->connection_ != NULL)
+                {
+                    PrintThread{} << "Sending response for " << *botName << std::endl;
+                    server->QueueResponse(client->connection_, response);
+                    server->SendResponse();
+                    LastRequest = std::time(nullptr);
+                }
+                else
+                {
+                    CurrentExitCase = ExitCase::ClientTimeout;
+                }
+            }
+            if (difftime(std::time(nullptr),LastRequest) > 5)
+            {
+                PrintThread{} << "No new requests/responses for (" << *botName <<")" << std::endl;
+                CurrentExitCase = ExitCase::ClientTimeout;
+            }
+        }
+        return CurrentExitCase;
+    }
+    catch (const std::exception& e)
+    {
+        PrintThread{} << e.what() << std::endl;
+        return ExitCase::ClientTimeout;
+    }
 }
 
 bool LadderManager::SaveReplay(sc2::Connection *client, const std::string& path) {
-	sc2::ProtoInterface proto;
-	sc2::GameRequestPtr request = proto.MakeRequest();
-	request->mutable_save_replay();
-	SendDataToConnection(client, request.get());
-	SC2APIProtocol::Response* replay_response = nullptr;
-	if (!client->Receive(replay_response, 10000))
-	{
-//		std::cout << "Failed to receive replay response" << std::endl;
-		return false;
-	}
+    sc2::ProtoInterface proto;
+    sc2::GameRequestPtr request = proto.MakeRequest();
+    request->mutable_save_replay();
+    SendDataToConnection(client, request.get());
+    SC2APIProtocol::Response* replay_response = nullptr;
+    if (!client->Receive(replay_response, 10000))
+    {
+        //		std::cout << "Failed to receive replay response" << std::endl;
+        return false;
+    }
 
-	const SC2APIProtocol::ResponseSaveReplay& response_replay = replay_response->save_replay();
+    const SC2APIProtocol::ResponseSaveReplay& response_replay = replay_response->save_replay();
 
-	if (response_replay.data().size() == 0) {
-		return false;
-	}
+    if (response_replay.data().size() == 0) {
+        return false;
+    }
 
-	std::ofstream file;
-	file.open(path, std::fstream::binary);
-	if (!file.is_open()) {
-		return false;
-	}
+    std::ofstream file;
+    file.open(path, std::fstream::binary);
+    if (!file.is_open()) {
+        return false;
+    }
 
-	file.write(&response_replay.data()[0], response_replay.data().size());
-	return true;
+    file.write(&response_replay.data()[0], response_replay.data().size());
+    return true;
 }
 
 bool LadderManager::ProcessObservationResponse(SC2APIProtocol::ResponseObservation Response, std::vector<sc2::PlayerResult> *PlayerResults)
 {
-	if (Response.player_result_size())
-	{
-		PlayerResults->clear();
-		for (const auto& player_result : Response.player_result()) {
-			PlayerResults->push_back(sc2::PlayerResult(player_result.player_id(), sc2::ConvertGameResultFromProto(player_result.result())));
-		}
-		return true;
-	}
-	return false;
+    if (Response.player_result_size())
+    {
+        PlayerResults->clear();
+        for (const auto& player_result : Response.player_result()) {
+            PlayerResults->push_back(sc2::PlayerResult(player_result.player_id(), sc2::ConvertGameResultFromProto(player_result.result())));
+        }
+        return true;
+    }
+    return false;
 }
 
 std::string LadderManager::GetBotCommandLine(const BotConfig &AgentConfig, int GamePort, int StartPort, const std::string &OpponentId, bool CompOpp, sc2::Race CompRace, sc2::Difficulty CompDifficulty)
 {
-	// Add bot type specific command line needs
-	std::string OutCmdLine;
-	switch (AgentConfig.Type)
-	{
-	case Python:
-	{
-		OutCmdLine = Config->GetValue("PythonBinary") + " " + AgentConfig.FileName;
-		break;
-	}
-	case Wine:
-	{
-		OutCmdLine = "wine " + AgentConfig.FileName;
-		break;
-	}
-	case Mono:
-	{
-		OutCmdLine = "mono " + AgentConfig.FileName;
-		break;
-	}
-	case DotNetCore:
-	{
-		OutCmdLine = "dotnet " + AgentConfig.FileName;
-		break;
-	}
-	case CommandCenter:
-	{
-		OutCmdLine = Config->GetValue("CommandCenterPath") + " --ConfigFile " + AgentConfig.FileName;
-		break;
-	}
-	case BinaryCpp:
-	{
-		OutCmdLine = AgentConfig.RootPath + AgentConfig.FileName;
-		break;
-	}
-	case Java:
-	{
-		OutCmdLine = "java -jar " + AgentConfig.FileName;
-		break;
-	}
-	case DefaultBot: {} // BlizzardAI - doesn't need any command line arguments
-	}
+    // Add bot type specific command line needs
+    std::string OutCmdLine;
+    switch (AgentConfig.Type)
+    {
+    case Python:
+    {
+        OutCmdLine = Config->GetValue("PythonBinary") + " " + AgentConfig.FileName;
+        break;
+    }
+    case Wine:
+    {
+        OutCmdLine = "wine " + AgentConfig.FileName;
+        break;
+    }
+    case Mono:
+    {
+        OutCmdLine = "mono " + AgentConfig.FileName;
+        break;
+    }
+    case DotNetCore:
+    {
+        OutCmdLine = "dotnet " + AgentConfig.FileName;
+        break;
+    }
+    case CommandCenter:
+    {
+        OutCmdLine = Config->GetValue("CommandCenterPath") + " --ConfigFile " + AgentConfig.FileName;
+        break;
+    }
+    case BinaryCpp:
+    {
+        OutCmdLine = AgentConfig.RootPath + AgentConfig.FileName;
+        break;
+    }
+    case Java:
+    {
+        OutCmdLine = "java -jar " + AgentConfig.FileName;
+        break;
+    }
+    case DefaultBot: {} // BlizzardAI - doesn't need any command line arguments
+    }
 
-	// Add universal arguments
-	OutCmdLine += " --GamePort " + std::to_string(GamePort) + " --StartPort " + std::to_string(StartPort) + " --LadderServer 127.0.0.1 --OpponentId " + OpponentId;
+    // Add universal arguments
+    OutCmdLine += " --GamePort " + std::to_string(GamePort) + " --StartPort " + std::to_string(StartPort) + " --LadderServer 127.0.0.1 --OpponentId " + OpponentId;
 
-	if (CompOpp)
-	{
-		OutCmdLine += " --ComputerOpponent 1 --ComputerRace " + GetRaceString(CompRace) + " --ComputerDifficulty " + GetDifficultyString(CompDifficulty);
-	}
-	if (AgentConfig.Args != "")
-	{
-		OutCmdLine += " " + AgentConfig.Args;
-	}
-	return OutCmdLine;
+    if (CompOpp)
+    {
+        OutCmdLine += " --ComputerOpponent 1 --ComputerRace " + GetRaceString(CompRace) + " --ComputerDifficulty " + GetDifficultyString(CompDifficulty);
+    }
+    if (AgentConfig.Args != "")
+    {
+        OutCmdLine += " " + AgentConfig.Args;
+    }
+    return OutCmdLine;
 }
 
 
 void ResolveMap(const std::string& map_name, SC2APIProtocol::RequestCreateGame* request, sc2::ProcessSettings process_settings) {
-	// BattleNet map
-	if (!sc2::HasExtension(map_name, ".SC2Map")) {
-		request->set_battlenet_map_name(map_name);
-		return;
-	}
+    // BattleNet map
+    if (!sc2::HasExtension(map_name, ".SC2Map")) {
+        request->set_battlenet_map_name(map_name);
+        return;
+    }
 
-	// Absolute path
-	SC2APIProtocol::LocalMap* local_map = request->mutable_local_map();
-	if (sc2::DoesFileExist(map_name)) {
-		local_map->set_map_path(map_name);
-		return;
-	}
+    // Absolute path
+    SC2APIProtocol::LocalMap* local_map = request->mutable_local_map();
+    if (sc2::DoesFileExist(map_name)) {
+        local_map->set_map_path(map_name);
+        return;
+    }
 
-	// Relative path - Game maps directory
-	std::string game_relative = sc2::GetGameMapsDirectory(process_settings.process_path) + map_name;
-	if (sc2::DoesFileExist(game_relative)) {
-		local_map->set_map_path(map_name);
-		return;
-	}
+    // Relative path - Game maps directory
+    std::string game_relative = sc2::GetGameMapsDirectory(process_settings.process_path) + map_name;
+    if (sc2::DoesFileExist(game_relative)) {
+        local_map->set_map_path(map_name);
+        return;
+    }
 
-	// Relative path - Library maps directory
-	std::string library_relative = sc2::GetLibraryMapsDirectory() + map_name;
-	if (sc2::DoesFileExist(library_relative)) {
-		local_map->set_map_path(library_relative);
-		return;
-	}
+    // Relative path - Library maps directory
+    std::string library_relative = sc2::GetLibraryMapsDirectory() + map_name;
+    if (sc2::DoesFileExist(library_relative)) {
+        local_map->set_map_path(library_relative);
+        return;
+    }
 
-	// Relative path - Remotely saved maps directory
-	local_map->set_map_path(map_name);
+    // Relative path - Remotely saved maps directory
+    local_map->set_map_path(map_name);
 }
 
 sc2::GameRequestPtr CreateStartGameRequest(const std::string &MapName, std::vector<sc2::PlayerSetup> players, sc2::ProcessSettings process_settings)
 {
-	sc2::ProtoInterface proto;
-	sc2::GameRequestPtr request = proto.MakeRequest();
+    sc2::ProtoInterface proto;
+    sc2::GameRequestPtr request = proto.MakeRequest();
 
-	SC2APIProtocol::RequestCreateGame* request_create_game = request->mutable_create_game();
-	for (const sc2::PlayerSetup& setup : players)
-	{
-		SC2APIProtocol::PlayerSetup* playerSetup = request_create_game->add_player_setup();
-		playerSetup->set_type(SC2APIProtocol::PlayerType(setup.type));
-		playerSetup->set_race(SC2APIProtocol::Race(int(setup.race) + 1));
-		playerSetup->set_difficulty(SC2APIProtocol::Difficulty(setup.difficulty));
-	}
-	ResolveMap(MapName, request_create_game, process_settings);
+    SC2APIProtocol::RequestCreateGame* request_create_game = request->mutable_create_game();
+    for (const sc2::PlayerSetup& setup : players)
+    {
+        SC2APIProtocol::PlayerSetup* playerSetup = request_create_game->add_player_setup();
+        playerSetup->set_type(SC2APIProtocol::PlayerType(setup.type));
+        playerSetup->set_race(SC2APIProtocol::Race(int(setup.race) + 1));
+        playerSetup->set_difficulty(SC2APIProtocol::Difficulty(setup.difficulty));
+    }
+    ResolveMap(MapName, request_create_game, process_settings);
 
-	request_create_game->set_realtime(false);
-	return request;
+    request_create_game->set_realtime(false);
+    return request;
 }
 
 sc2::GameResponsePtr LadderManager::CreateErrorResponse()
 {
-	const sc2::GameResponsePtr response = std::make_shared<SC2APIProtocol::Response>(SC2APIProtocol::Response());
-	return response;
+    const sc2::GameResponsePtr response = std::make_shared<SC2APIProtocol::Response>(SC2APIProtocol::Response());
+    return response;
 }
 
 sc2::GameRequestPtr LadderManager::CreateLeaveGameRequest()
 {
-	sc2::ProtoInterface proto;
-	sc2::GameRequestPtr request = proto.MakeRequest();
+    sc2::ProtoInterface proto;
+    sc2::GameRequestPtr request = proto.MakeRequest();
 
-	request->mutable_quit();
+    request->mutable_leave_game();
 
-	return request;
+    return request;
 }
 
 sc2::GameRequestPtr LadderManager::CreateQuitRequest()
 {
-	sc2::ProtoInterface proto;
-	sc2::GameRequestPtr request = proto.MakeRequest();
-	request->mutable_quit();
+    sc2::ProtoInterface proto;
+    sc2::GameRequestPtr request = proto.MakeRequest();
+    request->mutable_quit();
 
-	return request;
+    return request;
 }
 
 ResultType LadderManager::GetPlayerResults(sc2::Connection *client)
 {
-	if (client == nullptr)
-	{
-		return ResultType::ProcessingReplay;
-	}
-	sc2::ProtoInterface proto;
-	sc2::GameRequestPtr ObservationRequest = proto.MakeRequest();
-	ObservationRequest->mutable_observation();
-	SendDataToConnection(client, ObservationRequest.get());
+    if (client == nullptr)
+    {
+        return ResultType::ProcessingReplay;
+    }
+    sc2::ProtoInterface proto;
+    sc2::GameRequestPtr ObservationRequest = proto.MakeRequest();
+    ObservationRequest->mutable_observation();
+    SendDataToConnection(client, ObservationRequest.get());
 
-	SC2APIProtocol::Response* ObservationResponse = nullptr;
-	std::vector<sc2::PlayerResult> PlayerResults;
-	if (client->Receive(ObservationResponse, 100000))
-	{
-		ProcessObservationResponse(ObservationResponse->observation(), &PlayerResults);
-	}
-	if (PlayerResults.size() > 1)
-	{
-		if (PlayerResults.back().result == sc2::GameResult::Undecided)
-		{
-			return ResultType::ProcessingReplay;
-		}
-		else if (PlayerResults.back().result == sc2::GameResult::Tie)
-		{
-			return ResultType::Tie;
-		}
-		else if (PlayerResults.back().result == sc2::GameResult::Win)
-		{
-			if (PlayerResults.back().player_id == 1)
-			{
-				return ResultType::Player1Win;
-			}
-			else
-			{
-				return ResultType::Player2Win;
-			}
-		}
-		else if (PlayerResults.back().result == sc2::GameResult::Loss)
-		{
-			if (PlayerResults.back().player_id == 1)
-			{
-				return ResultType::Player2Win;
-			}
-			else
-			{
-				return ResultType::Player1Win;
-			}
+    SC2APIProtocol::Response* ObservationResponse = nullptr;
+    std::vector<sc2::PlayerResult> PlayerResults;
+    if (client->Receive(ObservationResponse, 100000))
+    {
+        ProcessObservationResponse(ObservationResponse->observation(), &PlayerResults);
+    }
+    if (PlayerResults.size() > 1)
+    {
+        if (PlayerResults.back().result == sc2::GameResult::Undecided)
+        {
+            return ResultType::ProcessingReplay;
+        }
+        else if (PlayerResults.back().result == sc2::GameResult::Tie)
+        {
+            return ResultType::Tie;
+        }
+        else if (PlayerResults.back().result == sc2::GameResult::Win)
+        {
+            if (PlayerResults.back().player_id == 1)
+            {
+                return ResultType::Player1Win;
+            }
+            else
+            {
+                return ResultType::Player2Win;
+            }
+        }
+        else if (PlayerResults.back().result == sc2::GameResult::Loss)
+        {
+            if (PlayerResults.back().player_id == 1)
+            {
+                return ResultType::Player2Win;
+            }
+            else
+            {
+                return ResultType::Player1Win;
+            }
 
-		}
-	}
-	return ResultType::ProcessingReplay;
+        }
+    }
+    return ResultType::ProcessingReplay;
 }
 
 bool LadderManager::SendDataToConnection(sc2::Connection *Connection, const SC2APIProtocol::Request *request)
 {
-	if (Connection->connection_ != nullptr)
-	{
-		Connection->Send(request);
-		return true;
-	}
-	return false;
+    if (Connection->connection_ != nullptr)
+    {
+        Connection->Send(request);
+        return true;
+    }
+    return false;
 }
 
 GameResult LadderManager::StartGameVsDefault(const BotConfig &Agent1, sc2::Race CompRace, sc2::Difficulty CompDifficulty, const std::string &Map)
 {
-	using namespace std::chrono_literals;
-	// Setup server that mimicks sc2.
-	std::string Agent1Path = GetBotCommandLine(Agent1, 5677, PORT_START, "", true, sc2::Race::Random, CompDifficulty);
-	if (Agent1Path == "" )
-	{
-		return GameResult();
-	}
+    using namespace std::chrono_literals;
+    // Setup server that mimicks sc2.
+    std::string Agent1Path = GetBotCommandLine(Agent1, 5677, PORT_START, "", true, sc2::Race::Random, CompDifficulty);
+    if (Agent1Path == "" )
+    {
+        return GameResult();
+    }
 
-	sc2::Server server;
-	
-	server.Listen("5677", "100000", "100000", "5");
+    sc2::Server server;
 
-	// Find game executable and run it.
-	sc2::ProcessSettings process_settings;
-	sc2::GameSettings game_settings;
-	sc2::ParseSettings(CoordinatorArgc, CoordinatorArgv, process_settings, game_settings);
-	uint64_t BotProcessId = sc2::StartProcess(process_settings.process_path,
-		{ "-listen", "127.0.0.1",
-		"-port", "5679",
-		"-displayMode", "0",
-		"-dataVersion", process_settings.data_version }
-	);
+    server.Listen("5677", "100000", "100000", "5");
 
-	// Connect to running sc2 process.
-	sc2::Connection client;
-	client.Connect("127.0.0.1", 5679, false);
-	int connectionAttemptsClient = 0;
-	while (!client.Connect("127.0.0.1", 5679, false))
-	{
-		connectionAttemptsClient++;
-		sc2::SleepFor(1000);
-		if (connectionAttemptsClient > 60)
-		{
-			PrintThread{} << "Failed to connect client 1. BotProcessID: " << BotProcessId << std::endl;
-			return GameResult();
-		}
-	}
+    // Find game executable and run it.
+    sc2::ProcessSettings process_settings;
+    sc2::GameSettings game_settings;
+    sc2::ParseSettings(CoordinatorArgc, CoordinatorArgv, process_settings, game_settings);
+    uint64_t BotProcessId = sc2::StartProcess(process_settings.process_path,
+    { "-listen", "127.0.0.1",
+      "-port", "5679",
+      "-displayMode", "0",
+      "-dataVersion", process_settings.data_version }
+                                              );
 
-	std::vector<sc2::PlayerSetup> Players;
-	Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent1.Race, nullptr, sc2::Easy));
-	Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Computer, sc2::Race::Random, nullptr, CompDifficulty));
-	sc2::GameRequestPtr Create_game_request = CreateStartGameRequest(Map, Players, process_settings);
-	SendDataToConnection(&client, Create_game_request.get());
+    // Connect to running sc2 process.
+    sc2::Connection client;
+    client.Connect("127.0.0.1", 5679, false);
+    int connectionAttemptsClient = 0;
+    while (!client.Connect("127.0.0.1", 5679, false))
+    {
+        connectionAttemptsClient++;
+        sc2::SleepFor(1000);
+        if (connectionAttemptsClient > 60)
+        {
+            PrintThread{} << "Failed to connect client 1. BotProcessID: " << BotProcessId << std::endl;
+            return GameResult();
+        }
+    }
 
-	SC2APIProtocol::Response* create_response = nullptr;
-	if (client.Receive(create_response, 100000))
-	{
-		PrintThread{} << "Recieved create game response " << create_response->data().DebugString() << std::endl;
-		if (ProcessResponse(create_response->create_game()))
-		{
-			PrintThread{} << "Create game successful" << std::endl << std::endl;
-		}
-	}
-	unsigned long ProcessId;
-	auto bot1ProgramThread = std::thread(StartBotProcess,Agent1, Agent1Path, &ProcessId);
-	sc2::SleepFor(1000);
+    std::vector<sc2::PlayerSetup> Players;
+    Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent1.Race, nullptr, sc2::Easy));
+    Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Computer, sc2::Race::Random, nullptr, CompDifficulty));
+    sc2::GameRequestPtr Create_game_request = CreateStartGameRequest(Map, Players, process_settings);
+    SendDataToConnection(&client, Create_game_request.get());
 
-	PrintThread{} << "Monitoring client of: " << Agent1.BotName << std::endl;
-	float_t AvgFrameTime = 0;
-	int32_t GameLoop;
-	auto bot1UpdateThread = std::async(GameUpdate, &client, &server,&Agent1.BotName, MaxGameTime, MaxRealGameTime, &AvgFrameTime, &GameLoop);
-	sc2::SleepFor(1000);
+    SC2APIProtocol::Response* create_response = nullptr;
+    if (client.Receive(create_response, 100000))
+    {
+        PrintThread{} << "Recieved create game response " << create_response->data().DebugString() << std::endl;
+        if (ProcessResponse(create_response->create_game()))
+        {
+            PrintThread{} << "Create game successful" << std::endl << std::endl;
+        }
+    }
+    unsigned long ProcessId;
+    auto bot1ProgramThread = std::thread(StartBotProcess,Agent1, Agent1Path, &ProcessId);
+    sc2::SleepFor(1000);
 
-	ResultType CurrentResult = ResultType::InitializationError;
-	bool GameRunning = true;
-	//sc2::ProtoInterface proto_1;
-	//std::vector<sc2::PlayerResult> Player1Results;
-	SleepFor(10000);
-	while (GameRunning)
-	{
+    PrintThread{} << "Monitoring client of: " << Agent1.BotName << std::endl;
+    float_t AvgFrameTime = 0;
+    int32_t GameLoop;
+    auto bot1UpdateThread = std::async(GameUpdate, &client, &server,&Agent1.BotName, MaxGameTime, MaxRealGameTime, &AvgFrameTime, &GameLoop);
+    sc2::SleepFor(1000);
 
-		auto update1status = bot1UpdateThread.wait_for(1s);
-		if (update1status == std::future_status::ready)
-		{
-			ExitCase BotExitCase = bot1UpdateThread.get();
-			if (BotExitCase == ExitCase::ClientRequestExit)
-			{
-				// If Player 1 has requested exit, he has surrendered, and player 2 is awarded the win
-				CurrentResult = ResultType::Player2Win;
-			}
-			else if (BotExitCase == ExitCase::ClientTimeout)
-			{
-				CurrentResult = ResultType::Player1Crash;
-			}
-			else if (BotExitCase == ExitCase::GameTimeout)
-			{
-				CurrentResult = ResultType::Timeout;
-			}
-			else
-			{
-				CurrentResult = ResultType::ProcessingReplay;
-			}
+    ResultType CurrentResult = ResultType::InitializationError;
+    bool GameRunning = true;
+    //sc2::ProtoInterface proto_1;
+    //std::vector<sc2::PlayerResult> Player1Results;
+    SleepFor(10000);
+    while (GameRunning)
+    {
 
-			GameRunning = false;
-			break;
-		}
-	}
-	if (CurrentResult == ResultType::ProcessingReplay)
-	{
-		CurrentResult = GetPlayerResults(&client);
-	}
+        auto update1status = bot1UpdateThread.wait_for(1s);
+        if (update1status == std::future_status::ready)
+        {
+            ExitCase BotExitCase = bot1UpdateThread.get();
+            if (BotExitCase == ExitCase::ClientRequestExit)
+            {
+                // If Player 1 has requested exit, he has surrendered, and player 2 is awarded the win
+                CurrentResult = ResultType::Player2Win;
+            }
+            else if (BotExitCase == ExitCase::ClientTimeout)
+            {
+                CurrentResult = ResultType::Player1Crash;
+            }
+            else if (BotExitCase == ExitCase::GameTimeout)
+            {
+                CurrentResult = ResultType::Timeout;
+            }
+            else
+            {
+                CurrentResult = ResultType::ProcessingReplay;
+            }
 
-	std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
-	std::string ReplayFile = ReplayDir + Agent1.BotName + "v" + GetDifficultyString(CompDifficulty) + "-" + RemoveMapExtension(Map) + ".Sc2Replay";
-	ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
+            GameRunning = false;
+            break;
+        }
+    }
+    if (CurrentResult == ResultType::ProcessingReplay)
+    {
+        CurrentResult = GetPlayerResults(&client);
+    }
 
-	SaveReplay(&client, ReplayFile);
-	if (!SendDataToConnection(&client, CreateLeaveGameRequest().get()))
-	{
-		PrintThread{} << "CreateLeaveGameRequest failed" << std::endl;
-	}
+    std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
+    std::string ReplayFile = ReplayDir + Agent1.BotName + "v" + GetDifficultyString(CompDifficulty) + "-" + RemoveMapExtension(Map) + ".Sc2Replay";
+    ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
 
-	bot1ProgramThread.join();
-	GameResult result;
-	result.Result = CurrentResult;
-	return result;
+    SaveReplay(&client, ReplayFile);
+    if (!SendDataToConnection(&client, CreateLeaveGameRequest().get()))
+    {
+        PrintThread{} << "CreateLeaveGameRequest failed" << std::endl;
+    }
+
+    bot1ProgramThread.join();
+    GameResult result;
+    result.Result = CurrentResult;
+    return result;
 }
 
 GameResult LadderManager::StartGame(const BotConfig &Agent1, const BotConfig &Agent2, const std::string &Map)
 {
-	
-	using namespace std::chrono_literals;
-	// Setup server that mimicks sc2.
-	std::string Agent1Path = GetBotCommandLine(Agent1, 5677, PORT_START, Agent2.PlayerId);
-	std::string Agent2Path = GetBotCommandLine(Agent2, 5678, PORT_START, Agent1.PlayerId);
-	if (Agent1Path == "" || Agent2Path == "")
-	{
-		return GameResult();
-	}
-	sc2::Server server;
-	sc2::Server server2;
-	server.Listen("5677", "100000", "100000", "5");
-	server2.Listen("5678", "100000", "100000", "5");
-	// Find game executable and run it.
-	sc2::ProcessSettings process_settings;
-	sc2::GameSettings game_settings;
-	sc2::ParseSettings(CoordinatorArgc, CoordinatorArgv, process_settings, game_settings);
-	uint64_t GameClientPid1 = sc2::StartProcess(process_settings.process_path,
-	{ "-listen", "127.0.0.1",
-		"-port", "5679",
-		"-displayMode", "0",
-		"-dataVersion", process_settings.data_version }
-	);
-	uint64_t GameClientPid2 = sc2::StartProcess(process_settings.process_path,
-		{ "-listen", "127.0.0.1",
-		"-port", "5680",
-		"-displayMode", "0",
-		"-dataVersion", process_settings.data_version }
-	);
 
-	// Connect to running sc2 process.
-	sc2::Connection client;
-	int connectionAttemptsClient1 = 0;
-	while (!client.Connect("127.0.0.1", 5679, false))
-	{
-		connectionAttemptsClient1++;
-		sc2::SleepFor(1000);
-		if (connectionAttemptsClient1 > 60)
-		{
-			PrintThread{} << "Failed to connect client 1. BotProcessID: " << GameClientPid1 << std::endl;
-			return GameResult();
-		}
-	}
-	sc2::Connection client2;
-	int connectionAttemptsClient2 = 0;
-	while (!client2.Connect("127.0.0.1", 5680, false))
-	{
-		connectionAttemptsClient2++;
-		sc2::SleepFor(1000);
-		if (connectionAttemptsClient2 > 60)
-		{
-			PrintThread{} << "Failed to connect client 2. BotProcessID: " << GameClientPid2 << std::endl;
-			return GameResult();
-		}
-	}
+    using namespace std::chrono_literals;
+    // Setup server that mimicks sc2.
+    std::string Agent1Path = GetBotCommandLine(Agent1, 5677, PORT_START, Agent2.PlayerId);
+    std::string Agent2Path = GetBotCommandLine(Agent2, 5678, PORT_START, Agent1.PlayerId);
+    if (Agent1Path == "" || Agent2Path == "")
+    {
+        return GameResult();
+    }
+    sc2::Server server;
+    sc2::Server server2;
+    server.Listen("5677", "100000", "100000", "5");
+    server2.Listen("5678", "100000", "100000", "5");
+    // Find game executable and run it.
+    sc2::ProcessSettings process_settings;
+    sc2::GameSettings game_settings;
+    sc2::ParseSettings(CoordinatorArgc, CoordinatorArgv, process_settings, game_settings);
+    uint64_t GameClientPid1 = sc2::StartProcess(process_settings.process_path,
+    { "-listen", "127.0.0.1",
+      "-port", "5679",
+      "-displayMode", "0",
+      "-dataVersion", process_settings.data_version }
+                                                );
+    uint64_t GameClientPid2 = sc2::StartProcess(process_settings.process_path,
+    { "-listen", "127.0.0.1",
+      "-port", "5680",
+      "-displayMode", "0",
+      "-dataVersion", process_settings.data_version }
+                                                );
 
-	std::vector<sc2::PlayerSetup> Players;
+    // Connect to running sc2 process.
+    sc2::Connection client;
+    int connectionAttemptsClient1 = 0;
+    while (!client.Connect("127.0.0.1", 5679, false))
+    {
+        connectionAttemptsClient1++;
+        sc2::SleepFor(1000);
+        if (connectionAttemptsClient1 > 60)
+        {
+            PrintThread{} << "Failed to connect client 1. BotProcessID: " << GameClientPid1 << std::endl;
+            return GameResult();
+        }
+    }
+    sc2::Connection client2;
+    int connectionAttemptsClient2 = 0;
+    while (!client2.Connect("127.0.0.1", 5680, false))
+    {
+        connectionAttemptsClient2++;
+        sc2::SleepFor(1000);
+        if (connectionAttemptsClient2 > 60)
+        {
+            PrintThread{} << "Failed to connect client 2. BotProcessID: " << GameClientPid2 << std::endl;
+            return GameResult();
+        }
+    }
 
-	Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent1.Race, nullptr, sc2::Easy));
-	Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent2.Race, nullptr, sc2::Easy));
-	sc2::GameRequestPtr Create_game_request = CreateStartGameRequest(Map, Players, process_settings);
-	client.Send(Create_game_request.get());
-	SC2APIProtocol::Response* create_response = nullptr;
-	if (client.Receive(create_response, 100000))
-	{
-		PrintThread{} << "Recieved create game response " << create_response->data().DebugString() << std::endl;
-		if (ProcessResponse(create_response->create_game()))
-		{
-			PrintThread{} << "Create game successful" << std::endl << std::endl;
-		}
-	}
-	unsigned long Bot1ThreadId = 0;
-	unsigned long Bot2ThreadId = 0;
-	auto bot1ProgramThread = std::async(&StartBotProcess, Agent1, Agent1Path, &Bot1ThreadId);
-	auto bot2ProgramThread = std::async(&StartBotProcess, Agent2, Agent2Path, &Bot2ThreadId);
-	sc2::SleepFor(500);
-	sc2::SleepFor(500);
+    std::vector<sc2::PlayerSetup> Players;
 
-	//toDo check here already if the bots crashed.
-	float_t Bot1AvgFrame = 0;
-	float_t Bot2AvgFrame = 0;
-	int32_t GameLoop;
-	auto bot1UpdateThread = std::async(&GameUpdate, &client, &server, &Agent1.BotName, MaxGameTime, MaxRealGameTime, &Bot1AvgFrame, &GameLoop);
-	auto bot2UpdateThread = std::async(&GameUpdate, &client2, &server2, &Agent2.BotName, MaxGameTime, MaxRealGameTime, &Bot2AvgFrame, nullptr);
-	sc2::SleepFor(1000);
+    Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent1.Race, nullptr, sc2::Easy));
+    Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent2.Race, nullptr, sc2::Easy));
+    sc2::GameRequestPtr Create_game_request = CreateStartGameRequest(Map, Players, process_settings);
+    client.Send(Create_game_request.get());
+    SC2APIProtocol::Response* create_response = nullptr;
+    if (client.Receive(create_response, 100000))
+    {
+        PrintThread{} << "Recieved create game response " << create_response->data().DebugString() << std::endl;
+        if (ProcessResponse(create_response->create_game()))
+        {
+            PrintThread{} << "Create game successful" << std::endl << std::endl;
+        }
+    }
+    unsigned long Bot1ThreadId = 0;
+    unsigned long Bot2ThreadId = 0;
+    auto bot1ProgramThread = std::async(&StartBotProcess, Agent1, Agent1Path, &Bot1ThreadId);
+    auto bot2ProgramThread = std::async(&StartBotProcess, Agent2, Agent2Path, &Bot2ThreadId);
+    sc2::SleepFor(500);
+    sc2::SleepFor(500);
 
-	ResultType CurrentResult = ResultType::InitializationError;
-	bool GameRunning = true;
-	//sc2::ProtoInterface proto_1;
-	while (GameRunning)
-	{
-		auto update1status = bot1UpdateThread.wait_for(1s);
-		auto update2status = bot2UpdateThread.wait_for(0ms);
-		auto thread1Status = bot1ProgramThread.wait_for(0ms);
-		auto thread2Status = bot2ProgramThread.wait_for(0ms);
-		if (update1status == std::future_status::ready)
-		{
-			ExitCase BotExitCase = bot1UpdateThread.get();
-			if (BotExitCase == ExitCase::ClientRequestExit)
-			{
-				// If Player 1 has requested exit, he has surrendered, and player 2 is awarded the win
-				CurrentResult = ResultType::Player2Win;
-			}
-			else if( BotExitCase == ExitCase::ClientTimeout)
-			{
-				CurrentResult = ResultType::Player1Crash;
-			}
-			else if (BotExitCase == ExitCase::GameTimeout)
-			{
-				CurrentResult = ResultType::Timeout;
-			}
-			else 
-			{
-				CurrentResult = ResultType::ProcessingReplay;
-			}
+    //toDo check here already if the bots crashed.
+    float_t Bot1AvgFrame = 0;
+    float_t Bot2AvgFrame = 0;
+    int32_t GameLoop;
+    auto bot1UpdateThread = std::async(&GameUpdate, &client, &server, &Agent1.BotName, MaxGameTime, MaxRealGameTime, &Bot1AvgFrame, &GameLoop);
+    auto bot2UpdateThread = std::async(&GameUpdate, &client2, &server2, &Agent2.BotName, MaxGameTime, MaxRealGameTime, &Bot2AvgFrame, nullptr);
+    sc2::SleepFor(1000);
 
-			GameRunning = false;
-			break;
-		}
-		if(update2status == std::future_status::ready)
-		{
-			ExitCase BotExitCase = bot2UpdateThread.get();
-			if (BotExitCase == ExitCase::ClientRequestExit)
-			{
-				// If Player 2 has requested exit, he has surrendered, and player 1 is awarded the win
-				CurrentResult = ResultType::Player1Win;
-			}
-			else if (BotExitCase == ExitCase::ClientTimeout)
-			{
-				CurrentResult = ResultType::Player2Crash;
-			}
-			else if (BotExitCase == ExitCase::GameTimeout)
-			{
-				CurrentResult = ResultType::Timeout;
-			}
-			else
-			{
-				CurrentResult = ResultType::ProcessingReplay;
-			}
+    ResultType CurrentResult = ResultType::InitializationError;
+    bool GameRunning = true;
+    //sc2::ProtoInterface proto_1;
+    while (GameRunning)
+    {
+        auto update1status = bot1UpdateThread.wait_for(1s);
+        auto update2status = bot2UpdateThread.wait_for(0ms);
+        auto thread1Status = bot1ProgramThread.wait_for(0ms);
+        auto thread2Status = bot2ProgramThread.wait_for(0ms);
+        if (update1status == std::future_status::ready)
+        {
+            ExitCase BotExitCase = bot1UpdateThread.get();
+            if (BotExitCase == ExitCase::ClientRequestExit)
+            {
+                // If Player 1 has requested exit, he has surrendered, and player 2 is awarded the win
+                CurrentResult = ResultType::Player2Win;
+            }
+            else if( BotExitCase == ExitCase::ClientTimeout)
+            {
+                CurrentResult = ResultType::Player1Crash;
+            }
+            else if (BotExitCase == ExitCase::GameTimeout)
+            {
+                CurrentResult = ResultType::Timeout;
+            }
+            else
+            {
+                CurrentResult = ResultType::ProcessingReplay;
+            }
 
-			GameRunning = false;
-			break;
-		}
-		if (thread1Status == std::future_status::ready)
-		{
-			CurrentResult = ResultType::Player1Crash;
-			GameRunning = false;
-		}
-		if (thread2Status == std::future_status::ready)
-		{
-			CurrentResult = ResultType::Player2Crash;
-			GameRunning = false;
-		}
+            GameRunning = false;
+            break;
+        }
+        if(update2status == std::future_status::ready)
+        {
+            ExitCase BotExitCase = bot2UpdateThread.get();
+            if (BotExitCase == ExitCase::ClientRequestExit)
+            {
+                // If Player 2 has requested exit, he has surrendered, and player 1 is awarded the win
+                CurrentResult = ResultType::Player1Win;
+            }
+            else if (BotExitCase == ExitCase::ClientTimeout)
+            {
+                CurrentResult = ResultType::Player2Crash;
+            }
+            else if (BotExitCase == ExitCase::GameTimeout)
+            {
+                CurrentResult = ResultType::Timeout;
+            }
+            else
+            {
+                CurrentResult = ResultType::ProcessingReplay;
+            }
 
-	}
-	if (CurrentResult == ResultType::ProcessingReplay)
-	{
-		CurrentResult = GetPlayerResults(&client);
-	}
-	if (CurrentResult == ResultType::ProcessingReplay)
-	{
-		CurrentResult = GetPlayerResults(&client2);
-	}
-	sc2::SleepFor(1000);
-	std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
+            GameRunning = false;
+            break;
+        }
+        if (thread1Status == std::future_status::ready)
+        {
+            CurrentResult = ResultType::Player1Crash;
+            GameRunning = false;
+        }
+        if (thread2Status == std::future_status::ready)
+        {
+            CurrentResult = ResultType::Player2Crash;
+            GameRunning = false;
+        }
 
-	std::string ReplayFile = ReplayDir + Agent1.BotName + "v" + Agent2.BotName + "-" + RemoveMapExtension(Map) + ".SC2Replay";
-	ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
-	if (!SaveReplay(&client, ReplayFile))
-	{
-		SaveReplay(&client2, ReplayFile);
-	}
-	sc2::SleepFor(1000);
-	if (!SendDataToConnection(&client, CreateLeaveGameRequest().get()))
-	{
-		PrintThread{} << "CreateLeaveGameRequest failed for Client 1." << std::endl;
-	}
-	sc2::SleepFor(1000);
-	if (!SendDataToConnection(&client2, CreateLeaveGameRequest().get()))
-	{
-		PrintThread{} << "CreateLeaveGameRequest failed for Client 2." << std::endl;
-	}
-	sc2::SleepFor(1000);
-	if (server.HasRequest() && server.connections_.size() > 0)
-	{
-		server.SendRequest(client.connection_);
-	}
-	sc2::SleepFor(1000);
-	if (server2.HasRequest() && server2.connections_.size() > 0)
-	{
-		server2.SendRequest(client2.connection_);
-	}
-	ChangeBotNames(ReplayFile, Agent1.BotName, Agent2.BotName);
+    }
+    if (CurrentResult == ResultType::ProcessingReplay)
+    {
+        CurrentResult = GetPlayerResults(&client);
+    }
+    if (CurrentResult == ResultType::ProcessingReplay)
+    {
+        CurrentResult = GetPlayerResults(&client2);
+    }
+    sc2::SleepFor(1000);
+    std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
 
-	if (CurrentResult == Player1Crash || CurrentResult == Player2Crash)
-	{
-		sc2::SleepFor(5000);
-		sc2::TerminateProcess(GameClientPid1);
-		sc2::TerminateProcess(GameClientPid2);
-		sc2::SleepFor(5000);
-		try
-		{
-			bot1UpdateThread.wait();
-			bot2UpdateThread.wait();
+    std::string ReplayFile = ReplayDir + Agent1.BotName + "v" + Agent2.BotName + "-" + RemoveMapExtension(Map) + ".SC2Replay";
+    ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
+    if (!SaveReplay(&client, ReplayFile))
+    {
+        SaveReplay(&client2, ReplayFile);
+    }
+    sc2::SleepFor(1000);
+    ChangeBotNames(ReplayFile, Agent1.BotName, Agent2.BotName);
+    auto bot1OnEndThread = std::async(&OnEnd, &client, &server, &Agent1.BotName);
+    auto bot2OnEndThread = std::async(&OnEnd, &client2, &server2, &Agent2.BotName);
+    sc2::SleepFor(1000);
+    if (!SendDataToConnection(&client, CreateLeaveGameRequest().get()))
+    {
+        PrintThread{} << "CreateLeaveGameRequest failed for Client 1." << std::endl;
+    }
+    sc2::SleepFor(1000);
+    if (!SendDataToConnection(&client2, CreateLeaveGameRequest().get()))
+    {
+        PrintThread{} << "CreateLeaveGameRequest failed for Client 2." << std::endl;
+    }
+    sc2::SleepFor(1000);
+    PrintThread{} << "test " << server.connections_.size() << std::endl;
+    PrintThread{} << "test " << server2.connections_.size() << std::endl;
+    sc2::SleepFor(5000);
+    sc2::TerminateProcess(GameClientPid1);
+    sc2::TerminateProcess(GameClientPid2);
+    sc2::SleepFor(5000);
+    if (server.HasRequest() && server.connections_.size() > 0)
+    {
+        server.SendRequest(client.connection_);
+    }
+    sc2::SleepFor(1000);
+    if (server2.HasRequest() && server2.connections_.size() > 0)
+    {
+        server2.SendRequest(client2.connection_);
+    }
+    /*
+    if (CurrentResult == Player1Crash || CurrentResult == Player2Crash)
+    {
+        sc2::SleepFor(5000);
+        sc2::TerminateProcess(GameClientPid1);
+        sc2::TerminateProcess(GameClientPid2);
+        sc2::SleepFor(5000);
+        try
+        {
+            bot1UpdateThread.wait();
+            bot2UpdateThread.wait();
 
-		}
-		catch (const std::exception& e)
-		{
-			PrintThread{} << e.what() << std::endl <<" Unable to detect end of update thread.  Continuing" << std::endl;
-		}
+        }
+        catch (const std::exception& e)
+        {
+            PrintThread{} << e.what() << std::endl <<" Unable to detect end of update thread.  Continuing" << std::endl;
+        }
 
-	}
-	std::future_status bot1ProgStatus, bot2ProgStatus;
-	auto start = std::chrono::system_clock::now();
-	std::chrono::duration<double> elapsed_seconds;
-	while (elapsed_seconds.count() < 20)
-	{
-		bot1ProgStatus = bot1ProgramThread.wait_for(50ms);
-		bot2ProgStatus = bot2ProgramThread.wait_for(50ms);
-		if (bot1ProgStatus == std::future_status::ready && bot2ProgStatus == std::future_status::ready)
-		{
-			break;
-		}
-		elapsed_seconds = std::chrono::system_clock::now() - start;
-	}
-	if (bot1ProgStatus != std::future_status::ready)
-	{
-		PrintThread{} << "Failed to detect end of " << Agent1.BotName << " after 20s.  Killing" << std::endl;
-		KillBotProcess(Bot1ThreadId);
-	}
-	if (bot2ProgStatus != std::future_status::ready)
-	{
-		PrintThread{} << "Failed to detect end of " << Agent2.BotName << " after 20s.  Killing" << std::endl;
-		KillBotProcess(Bot2ThreadId);
-	}
-	GameResult Result;
-	Result.Result = CurrentResult;
-	Result.Bot1AvgFrame = Bot1AvgFrame;
-	Result.Bot2AvgFrame = Bot2AvgFrame;
-	Result.GameLoop = GameLoop;
-	return Result;
+    }
+    std::future_status bot1ProgStatus, bot2ProgStatus;
+    auto start = std::chrono::system_clock::now();
+    std::chrono::duration<double> elapsed_seconds;
+    while (elapsed_seconds.count() < 20)
+    {
+        bot1ProgStatus = bot1ProgramThread.wait_for(50ms);
+        bot2ProgStatus = bot2ProgramThread.wait_for(50ms);
+        if (bot1ProgStatus == std::future_status::ready && bot2ProgStatus == std::future_status::ready)
+        {
+            break;
+        }
+        elapsed_seconds = std::chrono::system_clock::now() - start;
+    }
+    if (bot1ProgStatus != std::future_status::ready)
+    {
+        PrintThread{} << "Failed to detect end of " << Agent1.BotName << " after 20s.  Killing" << std::endl;
+        KillBotProcess(Bot1ThreadId);
+    }
+    if (bot2ProgStatus != std::future_status::ready)
+    {
+        PrintThread{} << "Failed to detect end of " << Agent2.BotName << " after 20s.  Killing" << std::endl;
+        KillBotProcess(Bot2ThreadId);
+    }
+    */
+    GameResult Result;
+    Result.Result = CurrentResult;
+    Result.Bot1AvgFrame = Bot1AvgFrame;
+    Result.Bot2AvgFrame = Bot2AvgFrame;
+    Result.GameLoop = GameLoop;
+    return Result;
 }
 
 
 LadderManager::LadderManager(int InCoordinatorArgc, char** inCoordinatorArgv)
 
-	: coordinator(nullptr)
-	, CoordinatorArgc(InCoordinatorArgc)
-	, CoordinatorArgv(inCoordinatorArgv)
-	, MaxGameTime(0)
-	, MaxRealGameTime(0)
-	, MaxEloDiff(0)
-	, ConfigFile("LadderManager.json")
-	, EnableReplayUploads(false)
-	, EnableServerLogin(false)
-	, EnablePlayerIds(false)
-	, Sc2Launched(false)
-	, Config(nullptr)
-	, PlayerIds(nullptr)
+    : coordinator(nullptr)
+    , CoordinatorArgc(InCoordinatorArgc)
+    , CoordinatorArgv(inCoordinatorArgv)
+    , MaxGameTime(0)
+    , MaxRealGameTime(0)
+    , MaxEloDiff(0)
+    , ConfigFile("LadderManager.json")
+    , EnableReplayUploads(false)
+    , EnableServerLogin(false)
+    , EnablePlayerIds(false)
+    , Sc2Launched(false)
+    , Config(nullptr)
+    , PlayerIds(nullptr)
 {
 }
 
 // Used for tests
 LadderManager::LadderManager(int InCoordinatorArgc, char** inCoordinatorArgv, const char *InConfigFile)
 
-	: coordinator(nullptr)
-	, CoordinatorArgc(InCoordinatorArgc)
-	, CoordinatorArgv(inCoordinatorArgv)
-	, MaxGameTime(0)
-	, MaxRealGameTime(0)
-	, MaxEloDiff(0)
-	, ConfigFile(InConfigFile)
-	, EnableReplayUploads(false)
-	, EnableServerLogin(false)
-	, EnablePlayerIds(false)
-	, Sc2Launched(false)
-	, Config(nullptr) 
-	, PlayerIds(nullptr)
+    : coordinator(nullptr)
+    , CoordinatorArgc(InCoordinatorArgc)
+    , CoordinatorArgv(inCoordinatorArgv)
+    , MaxGameTime(0)
+    , MaxRealGameTime(0)
+    , MaxEloDiff(0)
+    , ConfigFile(InConfigFile)
+    , EnableReplayUploads(false)
+    , EnableServerLogin(false)
+    , EnablePlayerIds(false)
+    , Sc2Launched(false)
+    , Config(nullptr)
+    , PlayerIds(nullptr)
 {
 }
 
 std::string LadderManager::GerneratePlayerId(size_t Length)
 {
-	static const char hexdigit[16] = { '0', '1','2','3','4','5','6','7','8','9','a','b','c','d','e','f' };
-	std::string outstring;
-	if (Length < 1)
-	{
-		return outstring;
+    static const char hexdigit[16] = { '0', '1','2','3','4','5','6','7','8','9','a','b','c','d','e','f' };
+    std::string outstring;
+    if (Length < 1)
+    {
+        return outstring;
 
-	}
-	--Length;
-	for (int i = 0; i < Length; ++i)
-	{
-		outstring.append(1, hexdigit[rand() % sizeof hexdigit]);
-	}
-	return outstring;
+    }
+    --Length;
+    for (int i = 0; i < Length; ++i)
+    {
+        outstring.append(1, hexdigit[rand() % sizeof hexdigit]);
+    }
+    return outstring;
 }
 
 bool LadderManager::LoadSetup()
 {
-	delete Config;
-	Config = new LadderConfig(ConfigFile);
-	if (!Config->ParseConfig())
-	{
-		PrintThread{} << "Unable to parse config (not found or not valid): " << ConfigFile << std::endl;
-		return false;
-	}
+    delete Config;
+    Config = new LadderConfig(ConfigFile);
+    if (!Config->ParseConfig())
+    {
+        PrintThread{} << "Unable to parse config (not found or not valid): " << ConfigFile << std::endl;
+        return false;
+    }
 
-	std::string PlayerIdFile = Config->GetValue("PlayerIdFile");
-	if (PlayerIdFile.length() > 0)
-	{
-		PlayerIds = new LadderConfig(PlayerIdFile);
-		EnablePlayerIds = true;
-	}
+    std::string PlayerIdFile = Config->GetValue("PlayerIdFile");
+    if (PlayerIdFile.length() > 0)
+    {
+        PlayerIds = new LadderConfig(PlayerIdFile);
+        EnablePlayerIds = true;
+    }
 
-	std::string MaxGameTimeString = Config->GetValue("MaxGameTime");
-	if (MaxGameTimeString.length() > 0)
-	{
-		MaxGameTime = std::stoi(MaxGameTimeString);
-	}
-	std::string MaxRealGameTimeString = Config->GetValue("MaxRealGameTime");
-	if (MaxRealGameTimeString.length() > 0)
-	{
-		MaxRealGameTime = std::stoi(MaxRealGameTimeString);
-	}
+    std::string MaxGameTimeString = Config->GetValue("MaxGameTime");
+    if (MaxGameTimeString.length() > 0)
+    {
+        MaxGameTime = std::stoi(MaxGameTimeString);
+    }
+    std::string MaxRealGameTimeString = Config->GetValue("MaxRealGameTime");
+    if (MaxRealGameTimeString.length() > 0)
+    {
+        MaxRealGameTime = std::stoi(MaxRealGameTimeString);
+    }
 
-	std::string EnableReplayUploadString = Config->GetValue("EnableReplayUpload");
-	if (EnableReplayUploadString == "True")
-	{
+    std::string EnableReplayUploadString = Config->GetValue("EnableReplayUpload");
+    if (EnableReplayUploadString == "True")
+    {
         EnableReplayUploads = true;
-	}
+    }
 
-	ResultsLogFile = Config->GetValue("ResultsLogFile");
+    ResultsLogFile = Config->GetValue("ResultsLogFile");
 
-	std::string EnableServerLoginString = Config->GetValue("EnableServerLogin");
-	if (EnableServerLoginString == "True")
-	{
+    std::string EnableServerLoginString = Config->GetValue("EnableServerLogin");
+    if (EnableServerLoginString == "True")
+    {
         EnableServerLogin = true;
-		ServerLoginAddress = Config->GetValue("ServerLoginAddress");
-		ServerUsername = Config->GetValue("ServerUsername");
-		ServerPassword = Config->GetValue("ServerPassword");
-	}
-	BotCheckLocation = Config->GetValue("BotInfoLocation");
+        ServerLoginAddress = Config->GetValue("ServerLoginAddress");
+        ServerUsername = Config->GetValue("ServerUsername");
+        ServerPassword = Config->GetValue("ServerPassword");
+    }
+    BotCheckLocation = Config->GetValue("BotInfoLocation");
 
-	std::string MaxEloDiffStr = Config->GetValue("MaxEloDiff");
-	if (MaxEloDiffStr.length() > 0)
-	{
-		MaxEloDiff = std::stoi(MaxEloDiffStr);
-	}
+    std::string MaxEloDiffStr = Config->GetValue("MaxEloDiff");
+    if (MaxEloDiffStr.length() > 0)
+    {
+        MaxEloDiff = std::stoi(MaxEloDiffStr);
+    }
 
-	return true;
+    return true;
 }
 
 void LadderManager::SaveJsonResult(const BotConfig &Bot1, const BotConfig &Bot2, const std::string  &Map, GameResult Result)
 {
-	rapidjson::Document ResultsDoc;
-	rapidjson::Document OriginalResults;
-	rapidjson::Document::AllocatorType& alloc = ResultsDoc.GetAllocator();
-	ResultsDoc.SetObject();
-	rapidjson::Value ResultsArray(rapidjson::kArrayType);
-	std::ifstream ifs(ResultsLogFile.c_str());
-	if (ifs)
-	{
-		std::stringstream buffer;
-		buffer << ifs.rdbuf();
-		bool parsingFailed = OriginalResults.Parse(buffer.str()).HasParseError();
-		if (!parsingFailed && OriginalResults.HasMember("Results"))
-		{
-			const rapidjson::Value & Results = OriginalResults["Results"];
-			for (const auto& val : Results.GetArray())
-			{
-				rapidjson::Value NewVal;
-				NewVal.CopyFrom(val, alloc);
-				ResultsArray.PushBack(NewVal, alloc);
-			}
-		}
-	}
+    rapidjson::Document ResultsDoc;
+    rapidjson::Document OriginalResults;
+    rapidjson::Document::AllocatorType& alloc = ResultsDoc.GetAllocator();
+    ResultsDoc.SetObject();
+    rapidjson::Value ResultsArray(rapidjson::kArrayType);
+    std::ifstream ifs(ResultsLogFile.c_str());
+    if (ifs)
+    {
+        std::stringstream buffer;
+        buffer << ifs.rdbuf();
+        bool parsingFailed = OriginalResults.Parse(buffer.str()).HasParseError();
+        if (!parsingFailed && OriginalResults.HasMember("Results"))
+        {
+            const rapidjson::Value & Results = OriginalResults["Results"];
+            for (const auto& val : Results.GetArray())
+            {
+                rapidjson::Value NewVal;
+                NewVal.CopyFrom(val, alloc);
+                ResultsArray.PushBack(NewVal, alloc);
+            }
+        }
+    }
 
-	rapidjson::Value NewResult(rapidjson::kObjectType);
-	NewResult.AddMember("Bot1", Bot1.BotName, ResultsDoc.GetAllocator());
-	NewResult.AddMember("Bot2", Bot2.BotName, alloc);
-	switch (Result.Result)
-	{
-	case Player1Win:
-	case Player2Crash:
-		NewResult.AddMember("Winner", Bot1.BotName, alloc);
-		break;
-	case Player2Win:
-	case Player1Crash:
-		NewResult.AddMember("Winner", Bot2.BotName, alloc);
-		break;
-	case Tie:
-	case Timeout:
-		NewResult.AddMember("Winner", "Tie", alloc);
-		break;
-	case InitializationError:
-	case Error:
-	case ProcessingReplay:
-		NewResult.AddMember("Winner", "Error", alloc);
-		break;
-	}
+    rapidjson::Value NewResult(rapidjson::kObjectType);
+    NewResult.AddMember("Bot1", Bot1.BotName, ResultsDoc.GetAllocator());
+    NewResult.AddMember("Bot2", Bot2.BotName, alloc);
+    switch (Result.Result)
+    {
+    case Player1Win:
+    case Player2Crash:
+        NewResult.AddMember("Winner", Bot1.BotName, alloc);
+        break;
+    case Player2Win:
+    case Player1Crash:
+        NewResult.AddMember("Winner", Bot2.BotName, alloc);
+        break;
+    case Tie:
+    case Timeout:
+        NewResult.AddMember("Winner", "Tie", alloc);
+        break;
+    case InitializationError:
+    case Error:
+    case ProcessingReplay:
+        NewResult.AddMember("Winner", "Error", alloc);
+        break;
+    }
 
-	NewResult.AddMember("Map", Map, alloc);
-	NewResult.AddMember("Result", GetResultType(Result.Result), alloc);
-	NewResult.AddMember("GameTime", Result.GameLoop, alloc);
-	ResultsArray.PushBack(NewResult, alloc);
-	ResultsDoc.AddMember("Results", ResultsArray, alloc);
-	std::ofstream ofs(ResultsLogFile.c_str());
-	rapidjson::OStreamWrapper osw(ofs);
-	rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(osw);
-	ResultsDoc.Accept(writer);
+    NewResult.AddMember("Map", Map, alloc);
+    NewResult.AddMember("Result", GetResultType(Result.Result), alloc);
+    NewResult.AddMember("GameTime", Result.GameLoop, alloc);
+    ResultsArray.PushBack(NewResult, alloc);
+    ResultsDoc.AddMember("Results", ResultsArray, alloc);
+    std::ofstream ofs(ResultsLogFile.c_str());
+    rapidjson::OStreamWrapper osw(ofs);
+    rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(osw);
+    ResultsDoc.Accept(writer);
 }
 
 
 void LadderManager::LoadAgents()
 {
-	std::string BotConfigFile = Config->GetValue("BotConfigFile");
-	if (BotConfigFile.length() < 1)
-	{
-		return;
-	}
-	std::ifstream t(BotConfigFile);
-	std::stringstream buffer;
-	buffer << t.rdbuf();
-	std::string BotConfigString = buffer.str();
-	rapidjson::Document doc;
-	bool parsingFailed = doc.Parse(BotConfigString.c_str()).HasParseError();
-	if (parsingFailed)
-	{
-		std::cerr << "Unable to parse bot config file: " << BotConfigFile << std::endl;
-		return;
-	}
-	if (doc.HasMember("Bots") && doc["Bots"].IsObject())
-	{
-		const rapidjson::Value & Bots = doc["Bots"];
-		for (auto itr = Bots.MemberBegin(); itr != Bots.MemberEnd(); ++itr)
-		{
-			BotConfig NewBot;
-			NewBot.BotName = itr->name.GetString();
-			const rapidjson::Value &val = itr->value;
+    std::string BotConfigFile = Config->GetValue("BotConfigFile");
+    if (BotConfigFile.length() < 1)
+    {
+        return;
+    }
+    std::ifstream t(BotConfigFile);
+    std::stringstream buffer;
+    buffer << t.rdbuf();
+    std::string BotConfigString = buffer.str();
+    rapidjson::Document doc;
+    bool parsingFailed = doc.Parse(BotConfigString.c_str()).HasParseError();
+    if (parsingFailed)
+    {
+        std::cerr << "Unable to parse bot config file: " << BotConfigFile << std::endl;
+        return;
+    }
+    if (doc.HasMember("Bots") && doc["Bots"].IsObject())
+    {
+        const rapidjson::Value & Bots = doc["Bots"];
+        for (auto itr = Bots.MemberBegin(); itr != Bots.MemberEnd(); ++itr)
+        {
+            BotConfig NewBot;
+            NewBot.BotName = itr->name.GetString();
+            const rapidjson::Value &val = itr->value;
 
-			if (val.HasMember("Race") && val["Race"].IsString())
-			{
-				NewBot.Race = GetRaceFromString(val["Race"].GetString());
-			}
-			else
-			{
-				std::cerr << "Unable to parse race for bot " << NewBot.BotName << std::endl;
-				continue;
-			}
-			if (val.HasMember("Type") && val["Type"].IsString())
-			{
-				NewBot.Type = GetTypeFromString(val["Type"].GetString());
-			}
-			else
-			{
-				std::cerr << "Unable to parse type for bot " << NewBot.BotName << std::endl;
-				continue;
-			}
-			if (NewBot.Type != DefaultBot)
-			{
-				if (val.HasMember("RootPath") && val["RootPath"].IsString())
-				{
-					NewBot.RootPath = val["RootPath"].GetString();
-					if (NewBot.RootPath.back() != '/')
-					{
-						NewBot.RootPath += '/';
-					}
-				}
-				else
-				{
-					std::cerr << "Unable to parse root path for bot " << NewBot.BotName << std::endl;
-					continue;
-				}
-				if (val.HasMember("FileName") && val["FileName"].IsString())
-				{
-					NewBot.FileName = val["FileName"].GetString();
-				}
-				else
-				{
-					std::cerr << "Unable to parse file name for bot " << NewBot.BotName << std::endl;
-					continue;
-				}
-				if (!sc2::DoesFileExist(NewBot.RootPath + NewBot.FileName))
-				{
-					std::cerr << "Unable to parse bot " << NewBot.BotName << std::endl;
-					std::cerr << "Is the path " << NewBot.RootPath << "correct?" << std::endl;
-					continue;
-				}
-				if (val.HasMember("Args") && val["Args"].IsString())
-				{
-					NewBot.Args = val["Arg"].GetString();
-				}
-				if (val.HasMember("Debug") && val["Debug"].IsBool()) {
-					NewBot.Debug = val["Debug"].GetBool();
-				}
-			}
-			else
-			{
-				if (val.HasMember("Difficulty") && val["Difficulty"].IsString())
-				{
-					NewBot.Difficulty = GetDifficultyFromString(val["Difficulty"].GetString());
-				}
-			}
-			if (EnablePlayerIds)
-			{
-				NewBot.PlayerId = PlayerIds->GetValue(NewBot.BotName);
-				if (NewBot.PlayerId.empty())
-				{
-					NewBot.PlayerId = GerneratePlayerId(PLAYER_ID_LENGTH);
-					PlayerIds->AddValue(NewBot.BotName, NewBot.PlayerId);
-					PlayerIds->WriteConfig();
-				}
-			}
-			BotConfigs.insert(std::make_pair(std::string(NewBot.BotName), NewBot));
+            if (val.HasMember("Race") && val["Race"].IsString())
+            {
+                NewBot.Race = GetRaceFromString(val["Race"].GetString());
+            }
+            else
+            {
+                std::cerr << "Unable to parse race for bot " << NewBot.BotName << std::endl;
+                continue;
+            }
+            if (val.HasMember("Type") && val["Type"].IsString())
+            {
+                NewBot.Type = GetTypeFromString(val["Type"].GetString());
+            }
+            else
+            {
+                std::cerr << "Unable to parse type for bot " << NewBot.BotName << std::endl;
+                continue;
+            }
+            if (NewBot.Type != DefaultBot)
+            {
+                if (val.HasMember("RootPath") && val["RootPath"].IsString())
+                {
+                    NewBot.RootPath = val["RootPath"].GetString();
+                    if (NewBot.RootPath.back() != '/')
+                    {
+                        NewBot.RootPath += '/';
+                    }
+                }
+                else
+                {
+                    std::cerr << "Unable to parse root path for bot " << NewBot.BotName << std::endl;
+                    continue;
+                }
+                if (val.HasMember("FileName") && val["FileName"].IsString())
+                {
+                    NewBot.FileName = val["FileName"].GetString();
+                }
+                else
+                {
+                    std::cerr << "Unable to parse file name for bot " << NewBot.BotName << std::endl;
+                    continue;
+                }
+                if (!sc2::DoesFileExist(NewBot.RootPath + NewBot.FileName))
+                {
+                    std::cerr << "Unable to parse bot " << NewBot.BotName << std::endl;
+                    std::cerr << "Is the path " << NewBot.RootPath << "correct?" << std::endl;
+                    continue;
+                }
+                if (val.HasMember("Args") && val["Args"].IsString())
+                {
+                    NewBot.Args = val["Arg"].GetString();
+                }
+                if (val.HasMember("Debug") && val["Debug"].IsBool()) {
+                    NewBot.Debug = val["Debug"].GetBool();
+                }
+            }
+            else
+            {
+                if (val.HasMember("Difficulty") && val["Difficulty"].IsString())
+                {
+                    NewBot.Difficulty = GetDifficultyFromString(val["Difficulty"].GetString());
+                }
+            }
+            if (EnablePlayerIds)
+            {
+                NewBot.PlayerId = PlayerIds->GetValue(NewBot.BotName);
+                if (NewBot.PlayerId.empty())
+                {
+                    NewBot.PlayerId = GerneratePlayerId(PLAYER_ID_LENGTH);
+                    PlayerIds->AddValue(NewBot.BotName, NewBot.PlayerId);
+                    PlayerIds->WriteConfig();
+                }
+            }
+            BotConfigs.insert(std::make_pair(std::string(NewBot.BotName), NewBot));
 
-		}
-	}
-	if (doc.HasMember("Maps") && doc["Maps"].IsArray())
-	{
-		const rapidjson::Value & Maps = doc["Maps"];
-		for (auto itr = Maps.Begin(); itr != Maps.End(); ++itr)
-		{
-			MapList.push_back(itr->GetString());
-		}
-	}
+        }
+    }
+    if (doc.HasMember("Maps") && doc["Maps"].IsArray())
+    {
+        const rapidjson::Value & Maps = doc["Maps"];
+        for (auto itr = Maps.Begin(); itr != Maps.End(); ++itr)
+        {
+            MapList.push_back(itr->GetString());
+        }
+    }
 }
 
 std::string LadderManager::RemoveMapExtension(const std::string& filename) {
-	size_t lastdot = filename.find_last_of(".");
-	if (lastdot == std::string::npos) return filename;
-	return filename.substr(0, lastdot);
+    size_t lastdot = filename.find_last_of(".");
+    if (lastdot == std::string::npos) return filename;
+    return filename.substr(0, lastdot);
 }
 
 void LadderManager::ChangeBotNames(const std::string ReplayFile, const std::string &Bot1Name, const std::string Bot2Name)
 {
-	std::string CmdLine = Config->GetValue("ReplayBotRenameProgram");
-	if (CmdLine.size() > 0)
-	{
-		CmdLine = CmdLine + " " + ReplayFile + " " + FIRST_PLAYER_NAME + " " + Bot1Name + " " + SECOND_PLAYER_NAME + " " + Bot2Name;
-		StartExternalProcess(CmdLine);
-	}
+    std::string CmdLine = Config->GetValue("ReplayBotRenameProgram");
+    if (CmdLine.size() > 0)
+    {
+        CmdLine = CmdLine + " " + ReplayFile + " " + FIRST_PLAYER_NAME + " " + Bot1Name + " " + SECOND_PLAYER_NAME + " " + Bot2Name;
+        StartExternalProcess(CmdLine);
+    }
 }
 
 bool LadderManager::UploadCmdLine(GameResult result, const Matchup &ThisMatch)
 {
-	std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
-	std::string UploadResultLocation = Config->GetValue("UploadResultLocation");
-	std::string RawMapName = RemoveMapExtension(ThisMatch.Map);
-	std::string ReplayFile;
-	if (ThisMatch.Agent2.Type == BotType::DefaultBot)
-	{
-		ReplayFile = ThisMatch.Agent1.BotName + "v" + GetDifficultyString(ThisMatch.Agent2.Difficulty) + "-" + RawMapName + ".Sc2Replay";
-	}
-	else
-	{
-		ReplayFile = ThisMatch.Agent1.BotName + "v" + ThisMatch.Agent2.BotName + "-" + RawMapName + ".Sc2Replay";
-	}
-	ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
-	std::string ReplayLoc = ReplayDir + ReplayFile;
+    std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
+    std::string UploadResultLocation = Config->GetValue("UploadResultLocation");
+    std::string RawMapName = RemoveMapExtension(ThisMatch.Map);
+    std::string ReplayFile;
+    if (ThisMatch.Agent2.Type == BotType::DefaultBot)
+    {
+        ReplayFile = ThisMatch.Agent1.BotName + "v" + GetDifficultyString(ThisMatch.Agent2.Difficulty) + "-" + RawMapName + ".Sc2Replay";
+    }
+    else
+    {
+        ReplayFile = ThisMatch.Agent1.BotName + "v" + ThisMatch.Agent2.BotName + "-" + RawMapName + ".Sc2Replay";
+    }
+    ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
+    std::string ReplayLoc = ReplayDir + ReplayFile;
 
-	std::string CurlCmd = "curl";
-	CurlCmd = CurlCmd + " -F Bot1Name=" + ThisMatch.Agent1.BotName;
-	CurlCmd = CurlCmd + " -F Bot1Race=" + std::to_string((int)ThisMatch.Agent1.Race);
-	CurlCmd = CurlCmd + " -F Bot2Name=" + ThisMatch.Agent2.BotName;
-	CurlCmd = CurlCmd + " -F Bot2Race=" + std::to_string((int)ThisMatch.Agent2.Race);
-	CurlCmd = CurlCmd + " -F Bot1AvgFrame=" + std::to_string(result.Bot1AvgFrame);
-	CurlCmd = CurlCmd + " -F Bot2AvgFrame=" + std::to_string(result.Bot2AvgFrame);
-	CurlCmd = CurlCmd + " -F Frames=" + std::to_string(result.GameLoop);
-	CurlCmd = CurlCmd + " -F Map=" + RawMapName;
-	CurlCmd = CurlCmd + " -F Result=" + GetResultType(result.Result);
-	CurlCmd = CurlCmd + " -F replayfile=@" + ReplayLoc;
-	CurlCmd = CurlCmd + " " + UploadResultLocation;
-	StartExternalProcess(CurlCmd);
-	return true;
+    std::string CurlCmd = "curl";
+    CurlCmd = CurlCmd + " -F Bot1Name=" + ThisMatch.Agent1.BotName;
+    CurlCmd = CurlCmd + " -F Bot1Race=" + std::to_string((int)ThisMatch.Agent1.Race);
+    CurlCmd = CurlCmd + " -F Bot2Name=" + ThisMatch.Agent2.BotName;
+    CurlCmd = CurlCmd + " -F Bot2Race=" + std::to_string((int)ThisMatch.Agent2.Race);
+    CurlCmd = CurlCmd + " -F Bot1AvgFrame=" + std::to_string(result.Bot1AvgFrame);
+    CurlCmd = CurlCmd + " -F Bot2AvgFrame=" + std::to_string(result.Bot2AvgFrame);
+    CurlCmd = CurlCmd + " -F Frames=" + std::to_string(result.GameLoop);
+    CurlCmd = CurlCmd + " -F Map=" + RawMapName;
+    CurlCmd = CurlCmd + " -F Result=" + GetResultType(result.Result);
+    CurlCmd = CurlCmd + " -F replayfile=@" + ReplayLoc;
+    CurlCmd = CurlCmd + " " + UploadResultLocation;
+    StartExternalProcess(CurlCmd);
+    return true;
 }
 
 
 bool LadderManager::LoginToServer()
 {
-	std::cout << "LoginToServer feature has been temporarily disabled";
-	return false;
+    std::cout << "LoginToServer feature has been temporarily disabled";
+    return false;
 }
 
 bool LadderManager::CheckDiactivatedBots() {
-	if (BotCheckLocation.empty())
-	{
-		return false;
-	}
-	std::string result = PerformRestRequest(BotCheckLocation);
-	if (result.empty())
-	{
-		return false;
-	}
-	rapidjson::Document doc;
-	bool parsingFailed = doc.Parse(result.c_str()).HasParseError();
-	if (parsingFailed)
-	{
-		std::cerr << "Unable to parse incoming bot config: " << ConfigFile << std::endl;
-		return false;
-	}
-	if (doc.HasMember("Bots") && doc["Bots"].IsArray())
-	{
-		const rapidjson::Value & Units = doc["Bots"];
-		for (const auto& val : Units.GetArray())
-		{
-			if (val.HasMember("name") && val["name"].IsString())
-			{
-				auto ThisBot = BotConfigs.find(val["name"].GetString());
-				if (ThisBot != BotConfigs.end())
-				{
-					if (val.HasMember("deactivated") && val.HasMember("deleted") && val["deactivated"].IsBool() && val["deleted"].IsBool())
-					{
-						if ((val["deactivated"].GetBool() || val["deleted"].GetBool()) && ThisBot->second.Enabled)
-						{
-							// Set bot to disabled
-							PrintThread{} << "Deactivating bot " << ThisBot->second.BotName << std::endl;
-							ThisBot->second.Enabled = false;
+    if (BotCheckLocation.empty())
+    {
+        return false;
+    }
+    std::string result = PerformRestRequest(BotCheckLocation);
+    if (result.empty())
+    {
+        return false;
+    }
+    rapidjson::Document doc;
+    bool parsingFailed = doc.Parse(result.c_str()).HasParseError();
+    if (parsingFailed)
+    {
+        std::cerr << "Unable to parse incoming bot config: " << ConfigFile << std::endl;
+        return false;
+    }
+    if (doc.HasMember("Bots") && doc["Bots"].IsArray())
+    {
+        const rapidjson::Value & Units = doc["Bots"];
+        for (const auto& val : Units.GetArray())
+        {
+            if (val.HasMember("name") && val["name"].IsString())
+            {
+                auto ThisBot = BotConfigs.find(val["name"].GetString());
+                if (ThisBot != BotConfigs.end())
+                {
+                    if (val.HasMember("deactivated") && val.HasMember("deleted") && val["deactivated"].IsBool() && val["deleted"].IsBool())
+                    {
+                        if ((val["deactivated"].GetBool() || val["deleted"].GetBool()) && ThisBot->second.Enabled)
+                        {
+                            // Set bot to disabled
+                            PrintThread{} << "Deactivating bot " << ThisBot->second.BotName << std::endl;
+                            ThisBot->second.Enabled = false;
 
-						}
-						else if (val["deactivated"].GetBool() == false && val["deleted"].GetBool() == false && ThisBot->second.Enabled == false)
-						{
-							// reenable a bot
-							PrintThread{} << "Activating bot " << ThisBot->second.BotName;
-							ThisBot->second.Enabled = true;
-						}
-					}
-					if (val.HasMember("elo") && val["elo"].IsString())
-					{
-						ThisBot->second.ELO = std::stoi(val["elo"].GetString());
-					}
-				}
+                        }
+                        else if (val["deactivated"].GetBool() == false && val["deleted"].GetBool() == false && ThisBot->second.Enabled == false)
+                        {
+                            // reenable a bot
+                            PrintThread{} << "Activating bot " << ThisBot->second.BotName;
+                            ThisBot->second.Enabled = true;
+                        }
+                    }
+                    if (val.HasMember("elo") && val["elo"].IsString())
+                    {
+                        ThisBot->second.ELO = std::stoi(val["elo"].GetString());
+                    }
+                }
 
-			}
-		}
-		return true;
-	}
-	return false;
+            }
+        }
+        return true;
+    }
+    return false;
 }
 
 bool LadderManager::IsBotEnabled(std::string BotName)
 {
-	auto ThisBot = BotConfigs.find(BotName);
-	if (ThisBot != BotConfigs.end())
-	{
-		return ThisBot->second.Enabled;
-	}
-	return false;
+    auto ThisBot = BotConfigs.find(BotName);
+    if (ThisBot != BotConfigs.end())
+    {
+        return ThisBot->second.Enabled;
+    }
+    return false;
 }
 bool LadderManager::IsInsideEloRange(std::string Bot1Name, std::string Bot2Name)
 {
-	if (MaxEloDiff == 0)
-	{
-		return true;
-	}
-	auto Bot1 = BotConfigs.find(Bot1Name);
-	auto Bot2 = BotConfigs.find(Bot2Name);
-	if(Bot1 != BotConfigs.end() && Bot2 != BotConfigs.end())
-	{
-		int32_t EloDiff = abs(Bot1->second.ELO - Bot2->second.ELO);
-		PrintThread{} << Bot1Name << " ELO: " << Bot1->second.ELO << " | " << Bot2Name << " ELO: " << Bot2->second.ELO << " | Diff: " << EloDiff << std::endl;
+    if (MaxEloDiff == 0)
+    {
+        return true;
+    }
+    auto Bot1 = BotConfigs.find(Bot1Name);
+    auto Bot2 = BotConfigs.find(Bot2Name);
+    if(Bot1 != BotConfigs.end() && Bot2 != BotConfigs.end())
+    {
+        int32_t EloDiff = abs(Bot1->second.ELO - Bot2->second.ELO);
+        PrintThread{} << Bot1Name << " ELO: " << Bot1->second.ELO << " | " << Bot2Name << " ELO: " << Bot2->second.ELO << " | Diff: " << EloDiff << std::endl;
 
-		if (Bot1->second.ELO > 0 && Bot2->second.ELO > 0 && abs(EloDiff) > MaxEloDiff)
-		{
-			return false;
-		}
-		return true;
-	}
-	return true;
+        if (Bot1->second.ELO > 0 && Bot2->second.ELO > 0 && abs(EloDiff) > MaxEloDiff)
+        {
+            return false;
+        }
+        return true;
+    }
+    return true;
 }
 
 void LadderManager::RunLadderManager()
 {
 
-	LoadAgents();
-	PrintThread{} << "Starting with " << MapList.size() << " maps:" << std::endl;
-	for (auto &map : MapList)
-	{
-		PrintThread{} << "* " << map << std::endl;
-	}
-	PrintThread{} << "Starting with agents: " << std::endl;
-	for (auto &Agent : BotConfigs)
-	{
-		PrintThread{} << Agent.second.BotName << std::endl;
-	}
-	std::string MatchListFile = Config->GetValue("MatchupListFile");
-	MatchupList *Matchups = new MatchupList(MatchListFile);
-	Matchups->GenerateMatches(BotConfigs, MapList);
-	Matchup NextMatch;
-	try
-	{
-		if (EnableServerLogin)
-		{
-			LoginToServer();
-		}
-		CheckDiactivatedBots();
-		while (Matchups->GetNextMatchup(NextMatch))
-		{
+    LoadAgents();
+    PrintThread{} << "Starting with " << MapList.size() << " maps:" << std::endl;
+    for (auto &map : MapList)
+    {
+        PrintThread{} << "* " << map << std::endl;
+    }
+    PrintThread{} << "Starting with agents: " << std::endl;
+    for (auto &Agent : BotConfigs)
+    {
+        PrintThread{} << Agent.second.BotName << std::endl;
+    }
+    std::string MatchListFile = Config->GetValue("MatchupListFile");
+    MatchupList *Matchups = new MatchupList(MatchListFile);
+    Matchups->GenerateMatches(BotConfigs, MapList);
+    Matchup NextMatch;
+    try
+    {
+        if (EnableServerLogin)
+        {
+            LoginToServer();
+        }
+        CheckDiactivatedBots();
+        while (Matchups->GetNextMatchup(NextMatch))
+        {
 
-			if (IsBotEnabled(NextMatch.Agent1.BotName) && IsBotEnabled(NextMatch.Agent2.BotName) && IsInsideEloRange(NextMatch.Agent1.BotName, NextMatch.Agent2.BotName))
-			{
-				GameResult result;
-				PrintThread{} << std::endl << "Starting " << NextMatch.Agent1.BotName << " vs " << NextMatch.Agent2.BotName << " on " << NextMatch.Map << std::endl;
-				if (NextMatch.Agent1.Type == DefaultBot || NextMatch.Agent2.Type == DefaultBot)
-				{
-					if (NextMatch.Agent1.Type == DefaultBot)
-					{
-						// Swap so computer is always player 2
-						BotConfig Temp = NextMatch.Agent1;
-						NextMatch.Agent1 = NextMatch.Agent2;
-						NextMatch.Agent2 = Temp;
-					}
-					result = StartGameVsDefault(NextMatch.Agent1, NextMatch.Agent2.Race, NextMatch.Agent2.Difficulty, NextMatch.Map);
-				}
-				else
-				{
-					result = StartGame(NextMatch.Agent1, NextMatch.Agent2, NextMatch.Map);
-				}
-				PrintThread{} << std::endl << "Game finished with result: " << GetResultType(result.Result) << std::endl;
-				if (EnableReplayUploads)
-				{
-					UploadCmdLine(result, NextMatch);
-				}
-				if (ResultsLogFile.size() > 0)
-				{
-					SaveJsonResult(NextMatch.Agent1, NextMatch.Agent2, NextMatch.Map, result);
-				}
-				Matchups->SaveMatchList();
-			}
-		}
-	}
-	catch (const std::exception& e)
-	{
-		PrintThread{} << "Exception in game " << e.what() << std::endl;
-		SaveError(NextMatch.Agent1.BotName, NextMatch.Agent2.BotName, NextMatch.Map);
-	}
-	
+            if (IsBotEnabled(NextMatch.Agent1.BotName) && IsBotEnabled(NextMatch.Agent2.BotName) && IsInsideEloRange(NextMatch.Agent1.BotName, NextMatch.Agent2.BotName))
+            {
+                GameResult result;
+                PrintThread{} << std::endl << "Starting " << NextMatch.Agent1.BotName << " vs " << NextMatch.Agent2.BotName << " on " << NextMatch.Map << std::endl;
+                if (NextMatch.Agent1.Type == DefaultBot || NextMatch.Agent2.Type == DefaultBot)
+                {
+                    if (NextMatch.Agent1.Type == DefaultBot)
+                    {
+                        // Swap so computer is always player 2
+                        BotConfig Temp = NextMatch.Agent1;
+                        NextMatch.Agent1 = NextMatch.Agent2;
+                        NextMatch.Agent2 = Temp;
+                    }
+                    result = StartGameVsDefault(NextMatch.Agent1, NextMatch.Agent2.Race, NextMatch.Agent2.Difficulty, NextMatch.Map);
+                }
+                else
+                {
+                    result = StartGame(NextMatch.Agent1, NextMatch.Agent2, NextMatch.Map);
+                }
+                PrintThread{} << std::endl << "Game finished with result: " << GetResultType(result.Result) << std::endl;
+                if (EnableReplayUploads)
+                {
+                    UploadCmdLine(result, NextMatch);
+                }
+                if (ResultsLogFile.size() > 0)
+                {
+                    SaveJsonResult(NextMatch.Agent1, NextMatch.Agent2, NextMatch.Map, result);
+                }
+                Matchups->SaveMatchList();
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        PrintThread{} << "Exception in game " << e.what() << std::endl;
+        SaveError(NextMatch.Agent1.BotName, NextMatch.Agent2.BotName, NextMatch.Map);
+    }
+
 }
 
 void LadderManager::SaveError(const std::string &Agent1, const std::string &Agent2, const std::string &Map)
 {
-	std::string ErrorListFile = Config->GetValue("ErrorListFile");
-	if (ErrorListFile == "")
-	{
-		return;
-	}
-	std::ofstream ofs(ErrorListFile, std::ofstream::app);
-	if (!ofs)
-	{
-		return;
-	}
-	ofs << "\"" + Agent1 + "\"vs\"" + Agent2 + "\" " + Map << std::endl;
-	ofs.close();
+    std::string ErrorListFile = Config->GetValue("ErrorListFile");
+    if (ErrorListFile == "")
+    {
+        return;
+    }
+    std::ofstream ofs(ErrorListFile, std::ofstream::app);
+    if (!ofs)
+    {
+        return;
+    }
+    ofs << "\"" + Agent1 + "\"vs\"" + Agent2 + "\" " + Map << std::endl;
+    ofs.close();
 }

--- a/src/sc2laddercore/ToolsUnix.cpp
+++ b/src/sc2laddercore/ToolsUnix.cpp
@@ -56,6 +56,8 @@ void StartBotProcess(const BotConfig &Agent, const std::string &CommandLine, uns
 
     if (pID == 0) // child
     {
+        // Move child to a new process group so that it can not kill the ladderManager
+        setpgid(0, 0);
         int ret = chdir(Agent.RootPath.c_str());
         if (ret < 0) {
             std::cerr << Agent.BotName +
@@ -166,5 +168,4 @@ std::string PerformRestRequest(const std::string &location)
 	}
 	return result;
 }
-
 #endif

--- a/src/sc2laddercore/ToolsWindows.cpp
+++ b/src/sc2laddercore/ToolsWindows.cpp
@@ -17,8 +17,8 @@ void StartBotProcess(const BotConfig &Agent, const std::string &CommandLine, uns
 	securityAttributes.nLength = sizeof(securityAttributes);
 	securityAttributes.lpSecurityDescriptor = NULL;
 	securityAttributes.bInheritHandle = TRUE;
-	std::string logFile = Agent.RootPath + "/stderr.log";
-	HANDLE stderrfile = CreateFile(logFile.c_str(),
+	std::string stderrLogFile = Agent.RootPath + "/stderr.log";
+	HANDLE stderrfile = CreateFile(stderrLogFile.c_str(),
 		FILE_APPEND_DATA,
 		FILE_SHARE_WRITE | FILE_SHARE_READ,
 		&securityAttributes,
@@ -29,7 +29,8 @@ void StartBotProcess(const BotConfig &Agent, const std::string &CommandLine, uns
 	HANDLE stdoutfile = NULL;
 	if (Agent.Debug)
 	{
-		stdoutfile = CreateFile("stdout.log",
+        std::string stdoutLogFile = Agent.RootPath + "/stdout.log";
+		stdoutfile = CreateFile(stdoutLogFile.c_str(),
 			FILE_APPEND_DATA,
 			FILE_SHARE_WRITE | FILE_SHARE_READ,
 			&securityAttributes,


### PR DESCRIPTION
### NOT A REAL MERGE REQUEST! JUST TO SYNC UP AND GATHER IDEAS HOW TO PROCEED!

This is how far I got with my attempts to fix the bug that the bots get stuck at the end of the game,

## Problem:
Currently one or both bots get stuck at the end of a match and need to be killed. A bot that needs to be killed never learns the result of the game. This is a problem for bots that want to use the result information in the next game.

## Attempts to fix the problem:
@Cryptyc mentioned that processing all requests/responses even after the game finished solves the problem. Just continuing to run the GameUpdate function for each bot is not an option, because this would close the SC2 client and would make saving the replay impossible. Therefore, I introduced a 'onEnd` function that processes all remaining requests/responses after the replay is saved for 10 seconds or if the SC2 client closes the connection, whatever happens sooner.
This alone did not fix the problem. The bots were still stuck even after the client closed the connection. So additionally I removed all leaveGame or quit requests in the bot interfaces I could find.

## Experiment:
I always ran a bot as player 1 and then player 2 against a reference python bot that does nothing ([these lines](https://github.com/Archiatrus/python-sc2-ladderbot/blob/master/example_bot.py#L8-L9) commented out). The LadderManager is in the version of this merge request. For the results below I used the newest SC2 Linux client. But I had the same experience on older versions.

## Expected outcome:
If two bots are matched against each other the stdout result should look like this. I highlighted the important line.

> 22-11-2018 19-42-13: Starting proxy for Python
> 22-11-2018 19-42-13: Starting proxy for Python_ref
> 22-11-2018 19-42-32: New status of Python_ref: in_game
> 22-11-2018 19-42-32: New status of Python: in_game
> 22-11-2018 19-42-45: New status of Python_ref: ended
> 22-11-2018 19-42-45: New status of Python: ended
> 22-11-2018 19-42-45: Python Exiting with GameEnd Average step time 1134.05, total time: 2.4677e+06, game loops: 2176
> 22-11-2018 19-42-45: Python_ref Exiting with GameEnd Average step time 1104.33, total time: 2.40302e+06, game loops: 2176
> 22-11-2018 19-42-46: Saving replay
> 22-11-2018 19-42-48: Processing last requests/responses for Python
> 22-11-2018 19-42-48: Sending request of Python
> 22-11-2018 19-42-48: Processing last requests/responses for Python_ref
> 22-11-2018 19-42-48: Sending request of Python_ref
> 22-11-2018 19-42-48: Sending response for Python
> 22-11-2018 19-42-48: Sending response for Python_ref
> 22-11-2018 19-42-50: Client disconnected (Python)
> 22-11-2018 19-42-50: Client disconnected (Python_ref)
> **22-11-2018 19-42-52: Both bots quit properly.**
> 22-11-2018 19-42-54: Game finished with result: Player1Win
> 22-11-2018 19-42-54: Finished.

If the line `Both bots quit properly.` appears the experiment was successful. If instead one sees `Failed to detect end of CppBot after 20s. Make sure the bot does not issue leaveGame or quit. Killing` or even worse just `Killed` the experiment failed.

# Linux:
## Python-sc2:
I used this [https://github.com/Archiatrus/python-sc2-ladderbot](https://github.com/Archiatrus/python-sc2-ladderbot) bot to test. Please note the [removal](https://github.com/Archiatrus/python-sc2-ladderbot/commit/9155d95e7d1e27c659e79232bc6b0dfd8039649e#diff-743b1adbf37db12e16e01ef62a6f7d72L80) of the quit AND leaveGame requests. The fix was successful and the following stdout.log was produced.

> Starting ladder game...
> INFO:sc2.protocol:Client status changed to Status.in_game (was None)
> INFO:root:Player id: 2
> Game started
> INFO:sc2.protocol:Client status changed to Status.ended (was Status.in_game)
> **OnGameEnd() was called.**
> INFO:root:Result for player id: 2: Result.Victory
> ERROR:asyncio:Unclosed client session
> client_session: <aiohttp.client.ClientSession object at 0x7f819ef3f4e0>
> **Result.Victory  against opponent  6c248b87d6ae33f**

`OnGameEnd` (or `on_end`) was called and the bot received the result to process it. I unfortunately do not know how to handle the `ERROR:asyncio:Unclosed client session` error. But it does not seem to interfere with the proper execution of the bot.

## C#
I also needed to remove one [leaveGame](https://github.com/Archiatrus/SC2-CSharpe-Starterkit/commit/93d92d80f5503c89e2bdf74f7bf4b45d1f9fb2db#diff-fd4b075c4a067f9699637a7154d9005eL231) request to get [https://github.com/Archiatrus/SC2-CSharpe-Starterkit](https://github.com/Archiatrus/SC2-CSharpe-Starterkit). But then the bot worked as expected, i.e., the above mentioned `Both bots quit properly.` appears. Also onEndGame could be called

[18:51:59 INFO] --> Connected
[18:52:16 INFO] RaxBot
....
[19:53:01 INFO] Result: Victory
[21:28:10 INFO] Terminated.

## C++
I created the simple bot [https://github.com/Archiatrus/CppBot](https://github.com/Archiatrus/CppBot). Unfortunately, the test fails here. Even worse, the bot not only crashes at the end of a game, it will also kill the ladderManager!

> ....
> 22-11-2018 20-19-09: Saving replay
> 22-11-2018 20-19-10: Processing last requests/responses for Cpp
> 22-11-2018 20-19-10: Sending request of Cpp
> 22-11-2018 20-19-10: Processing last requests/responses for Python_ref
> 22-11-2018 20-19-10: Sending request of Python_ref
> 22-11-2018 20-19-10: Sending response for Python_ref
> 22-11-2018 20-19-10: Sending response for Cpp
> **Killed**

The stderr.log of the bot is empty. The stdout.log shows the following.

> Connecting to port 5677
> Connected to 127.0.0.1:5677
> Waiting for the JoinGame response.
> WaitJoinGame finished successfully.
> Successfully joined game
> Result: 0

This means [LadderInterface.h#L71](https://github.com/Archiatrus/CppBot/blob/master/src/LadderInterface.h#L71) is reached. Which leads me to believe that the problem occurs during the deconstruction of the `coordinator`. Also note that `onGameEnd()` was not called.
Without sending the last requests/responses, i.e., without the new onEnd function the bot is stuck waiting for a response and needs to be killed. Faking a response was unsuccessful so far.

## Java
I have not yet tested a Java bot. My Java knowledge is unfortunately non-existent.

# Windows
In my preliminary tests last weekend all bots (even Java) passed the test on Windows. But I will thoroughly repeat the experiment as described above to double check this.

# Mac
I have no access to a mac. Maybe @alkurbatov can repeat the tests for me.

# Next steps
No idea. I do not know how to prevent the C++ bot from crashing and killing the ladderManager under Linux. That is why I made this merge request. Maybe someone has an idea...

(Also note that average frame calculation fails on Linux.)