### PR TITLE
Introduce Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: cpp
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      group: travis_lts
+      sudo: required
+    - os: osx
+      osx_image: xcode9.1
+
+before_install:
+  - . .travis/before-install.sh
+
+install:
+  - . .travis/install.sh
+
+script:
+  - mkdir build
+  - cd build
+  - cmake ../
+  - make

--- a/.travis/before-install.sh
+++ b/.travis/before-install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test # For C++14
+    sudo apt-get -qq update
+fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    sudo apt-get install -y g++-5
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 90
+    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 90
+else
+    # Apply compilation fixes for OS X.
+    git apply hacks/civetweb_compilation_fix.patch
+fi

--- a/hacks/civetweb_compilation_fix.patch
+++ b/hacks/civetweb_compilation_fix.patch
@@ -1,0 +1,13 @@
+diff --git a/s2client-api/contrib/civetweb/src/civetweb.c b/s2client-api/contrib/civetweb/src/civetweb.c
+index 29c7e00e..10a39c1e 100644
+--- a/s2client-api/contrib/civetweb/src/civetweb.c
++++ b/s2client-api/contrib/civetweb/src/civetweb.c
+@@ -17863,8 +17863,6 @@ mg_get_system_info_impl(char *buffer, int buflen)
+ #if defined(__GNUC__)
+ #pragma GCC diagnostic push
+ /* Disable bogus compiler warning -Wdate-time */
+-#pragma GCC diagnostic ignored "-Wall"
+-#pragma GCC diagnostic ignored "-Werror"
+ #endif
+ 		mg_snprintf(NULL,
+ 		            NULL,


### PR DESCRIPTION
This commit brings support of compilation checkouts on Linux and OS X using Travis CI.

Please pay attention that Travis itself should be enabled separately.

Also, after activation of Travis it is possible to add a badge, e.g. like here:
https://github.com/alkurbatov/suvorov-bot/edit/master/README.md