### PR TITLE
Initial support for Node.js bots

### DIFF
--- a/src/sc2laddercore/LadderGame.cpp
+++ b/src/sc2laddercore/LadderGame.cpp
@@ -26,7 +26,7 @@
 #include <chrono>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <sstream>   
+#include <sstream>
 #include <cctype>
 
 #include "Types.h"
@@ -454,6 +454,11 @@ std::string LadderGame::GetBotCommandLine(const BotConfig &AgentConfig, int Game
     case Java:
     {
         OutCmdLine = "java -jar " + AgentConfig.FileName;
+        break;
+    }
+    case NodeJS:
+    {
+        OutCmdLine = Config->GetValue("NodeJSBinary") + " " + AgentConfig.FileName;
         break;
     }
     case DefaultBot: {} // BlizzardAI - doesn't need any command line arguments

--- a/src/sc2laddercore/Types.h
+++ b/src/sc2laddercore/Types.h
@@ -33,7 +33,8 @@ enum BotType
 	Mono,
 	DotNetCore,
 	DefaultBot,
-    Java
+    Java,
+    NodeJS,
 };
 
 enum ResultType
@@ -269,6 +270,10 @@ static BotType GetTypeFromString(const std::string &TypeIn)
     else if (type == "java")
     {
         return BotType::Java;
+    }
+    else if (type == "nodejs")
+    {
+        return BotType::NodeJS;
     }
 	return BotType::BinaryCpp;
 }


### PR DESCRIPTION
- Here's an empty bot that can be used to verify this implementation: https://github.com/node-sc2/ladder-test-bot

- I *did* notice about this code: https://github.com/Cryptyc/Sc2LadderServer/blob/master/src/sc2laddercore/ToolsUnix.cpp#L99-L102 but node bots seem to exec identically whether `execv` or `execvp` is used... someone else will have to speak to if it needs to be there or not :)

- On windows, the installation suggestion would be:
  - Go to https://nodejs.org - click the big green button for the LTS to download the .msi
  - Run the .msi, installing node - this also puts nodejs bin in the system PATH
- On Linux, the installation suggestion would be:
  - `curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash`
  - `nvm install --lts` ... and that's it, node will be available local to the user and in their PATH