### PR TITLE
pass through realtime argv from process_settings to RequestCreateGame

### DIFF
--- a/src/sc2laddercore/LadderGame.cpp
+++ b/src/sc2laddercore/LadderGame.cpp
@@ -350,7 +350,7 @@ sc2::GameRequestPtr CreateStartGameRequest(const std::string &MapName, std::vect
     }
     ResolveMap(MapName, request_create_game, process_settings);
 
-    request_create_game->set_realtime(false);
+    request_create_game->set_realtime(process_settings.realtime);
     return request;
 }
 
@@ -523,7 +523,7 @@ sc2::GameRequestPtr LadderGame::CreateStartGameRequest(const std::string &MapNam
     }
     ResolveMap(MapName, request_create_game, process_settings);
 
-    request_create_game->set_realtime(false);
+    request_create_game->set_realtime(process_settings.realtime);
     return request;
 }
 


### PR DESCRIPTION
I took a stab at it. This should fix #115 methinks? It allows Sc2LadderServer.exe to be ran with `-r true` or `--realtime true` and the games will be started as such.