### PR TITLE
Proper game terminate

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(SYSTEM
 
 if (WIN32)
     include_directories(SYSTEM
-        ${PROJECT_SOURCE_DIR}/s2client-api/src/sc2utils/dirent.h
+        ${PROJECT_SOURCE_DIR}/s2client-api/src/sc2utils/
     )
 endif ()
 

--- a/src/sc2laddercore/AgentsConfig.cpp
+++ b/src/sc2laddercore/AgentsConfig.cpp
@@ -70,92 +70,82 @@ void AgentsConfig::LoadAgents(const std::string &BaseDirectory, const std::strin
 	if (doc.HasMember("Bots") && doc["Bots"].IsObject())
 	{
 		const rapidjson::Value & Bots = doc["Bots"];
-		for (auto itr = Bots.MemberBegin(); itr != Bots.MemberEnd(); ++itr)
-		{
-			BotConfig NewBot;
-			NewBot.BotName = itr->name.GetString();
-			const rapidjson::Value &val = itr->value;
+        for (auto itr = Bots.MemberBegin(); itr != Bots.MemberEnd(); ++itr)
+        {
+            BotConfig NewBot;
+            NewBot.BotName = itr->name.GetString();
+            const rapidjson::Value &val = itr->value;
 
-			if (val.HasMember("Race") && val["Race"].IsString())
-			{
-				NewBot.Race = GetRaceFromString(val["Race"].GetString());
-			}
-			else
-			{
-				std::cerr << "Unable to parse race for bot " << NewBot.BotName << std::endl;
-				continue;
-			}
-			if (val.HasMember("Type") && val["Type"].IsString())
-			{
-				NewBot.Type = GetTypeFromString(val["Type"].GetString());
-			}
-			else
-			{
-				std::cerr << "Unable to parse type for bot " << NewBot.BotName << std::endl;
-				continue;
-			}
-			if (NewBot.Type != DefaultBot)
-			{
-				if (val.HasMember("RootPath") && val["RootPath"].IsString())
-				{
-                    NewBot.RootPath = BaseDirectory;
-					if (NewBot.RootPath.back() != '/')
-					{
-						NewBot.RootPath += '/';
-					}
-                    NewBot.RootPath = NewBot.RootPath + val["RootPath"].GetString();
-                    if (NewBot.RootPath.back() != '/')
-                    {
-                        NewBot.RootPath += '/';
-                    }
-				}
-				else
-				{
-					std::cerr << "Unable to parse root path for bot " << NewBot.BotName << std::endl;
-					continue;
-				}
-				if (val.HasMember("FileName") && val["FileName"].IsString())
-				{
-					NewBot.FileName = val["FileName"].GetString();
-				}
-				else
-				{
-					std::cerr << "Unable to parse file name for bot " << NewBot.BotName << std::endl;
-					continue;
-				}
-				if (!sc2::DoesFileExist(NewBot.RootPath + NewBot.FileName))
-				{
-					std::cerr << "Unable to parse bot " << NewBot.BotName << std::endl;
-					std::cerr << "Is the path " << NewBot.RootPath << " correct?" << std::endl;
-					continue;
-				}
-				if (val.HasMember("Args") && val["Args"].IsString())
-				{
-					NewBot.Args = val["Args"].GetString();
-				}
-				if (val.HasMember("Debug") && val["Debug"].IsBool()) {
-					NewBot.Debug = val["Debug"].GetBool();
-				}
-			}
-			else
-			{
-				if (val.HasMember("Difficulty") && val["Difficulty"].IsString())
-				{
-					NewBot.Difficulty = GetDifficultyFromString(val["Difficulty"].GetString());
-				}
-			}
-            
+            if (val.HasMember("Race") && val["Race"].IsString())
+            {
+                NewBot.Race = GetRaceFromString(val["Race"].GetString());
+            }
+            else
+            {
+                std::cerr << "Unable to parse race for bot " << NewBot.BotName << std::endl;
+                continue;
+            }
+            if (val.HasMember("Type") && val["Type"].IsString())
+            {
+                NewBot.Type = GetTypeFromString(val["Type"].GetString());
+            }
+            else
+            {
+                std::cerr << "Unable to parse type for bot " << NewBot.BotName << std::endl;
+                continue;
+            }
+            if (val.HasMember("RootPath") && val["RootPath"].IsString())
+            {
+                NewBot.RootPath = BaseDirectory;
+                if (NewBot.RootPath.back() != '/')
+                {
+                    NewBot.RootPath += '/';
+                }
+                NewBot.RootPath = NewBot.RootPath + val["RootPath"].GetString();
+                if (NewBot.RootPath.back() != '/')
+                {
+                    NewBot.RootPath += '/';
+                }
+            }
+            else
+            {
+                std::cerr << "Unable to parse root path for bot " << NewBot.BotName << std::endl;
+                continue;
+            }
+            if (val.HasMember("FileName") && val["FileName"].IsString())
+            {
+                NewBot.FileName = val["FileName"].GetString();
+            }
+            else
+            {
+                std::cerr << "Unable to parse file name for bot " << NewBot.BotName << std::endl;
+                continue;
+            }
+            if (!sc2::DoesFileExist(NewBot.RootPath + NewBot.FileName))
+            {
+                std::cerr << "Unable to parse bot " << NewBot.BotName << std::endl;
+                std::cerr << "Is the path " << NewBot.RootPath << " correct?" << std::endl;
+                continue;
+            }
+            if (val.HasMember("Args") && val["Args"].IsString())
+            {
+                NewBot.Args = val["Args"].GetString();
+            }
+            if (val.HasMember("Debug") && val["Debug"].IsBool()) {
+                NewBot.Debug = val["Debug"].GetBool();
+            }
+
             if (EnablePlayerIds)
-			{
-				NewBot.PlayerId = PlayerIds->GetValue(NewBot.BotName);
-				if (NewBot.PlayerId.empty())
-				{
-					NewBot.PlayerId = GerneratePlayerId(PLAYER_ID_LENGTH);
-					PlayerIds->AddValue(NewBot.BotName, NewBot.PlayerId);
-					PlayerIds->WriteConfig();
-				}
-			}
-            
+            {
+                NewBot.PlayerId = PlayerIds->GetValue(NewBot.BotName);
+                if (NewBot.PlayerId.empty())
+                {
+                    NewBot.PlayerId = GerneratePlayerId(PLAYER_ID_LENGTH);
+                    PlayerIds->AddValue(NewBot.BotName, NewBot.PlayerId);
+                    PlayerIds->WriteConfig();
+                }
+            }
+
             std::string OutCmdLine = "";
             switch (NewBot.Type)
             {
@@ -199,7 +189,6 @@ void AgentsConfig::LoadAgents(const std::string &BaseDirectory, const std::strin
                 OutCmdLine = Config->GetValue("NodeJSBinary") + " " + NewBot.FileName;
                 break;
             }
-            case DefaultBot: {} // BlizzardAI - doesn't need any command line arguments
             }
 
             if (NewBot.Args != "")
@@ -208,9 +197,8 @@ void AgentsConfig::LoadAgents(const std::string &BaseDirectory, const std::strin
             }
 
             NewBot.executeCommand = OutCmdLine;
-			BotConfigs.insert(std::make_pair(std::string(NewBot.BotName), NewBot));
-
-		}
+            BotConfigs.insert(std::make_pair(std::string(NewBot.BotName), NewBot));
+        }
 	}
 
 }

--- a/src/sc2laddercore/AgentsConfig.cpp
+++ b/src/sc2laddercore/AgentsConfig.cpp
@@ -127,7 +127,7 @@ void AgentsConfig::LoadAgents(const std::string &BaseDirectory, const std::strin
 				if (!sc2::DoesFileExist(NewBot.RootPath + NewBot.FileName))
 				{
 					std::cerr << "Unable to parse bot " << NewBot.BotName << std::endl;
-					std::cerr << "Is the path " << NewBot.RootPath << "correct?" << std::endl;
+					std::cerr << "Is the path " << NewBot.RootPath << " correct?" << std::endl;
 					continue;
 				}
 				if (val.HasMember("Args") && val["Args"].IsString())

--- a/src/sc2laddercore/AgentsConfig.cpp
+++ b/src/sc2laddercore/AgentsConfig.cpp
@@ -12,10 +12,9 @@
 #include <string>
 
 AgentsConfig::AgentsConfig(LadderConfig *InLadderConfig)
-	: PlayerIds(nullptr),
-	EnablePlayerIds(false),
-	Config(InLadderConfig)
-
+    : Config(InLadderConfig),
+      PlayerIds(nullptr),
+      EnablePlayerIds(false)
 {
 	if (Config == nullptr)
 	{
@@ -35,6 +34,7 @@ AgentsConfig::AgentsConfig(LadderConfig *InLadderConfig)
 	{
 		ReadBotDirectories(Config->GetValue("BaseBotDirectory"));
 	}
+
 }
 
 void AgentsConfig::ReadBotDirectories(const std::string &BaseDirectory)
@@ -52,7 +52,6 @@ void AgentsConfig::ReadBotDirectories(const std::string &BaseDirectory)
 
 void AgentsConfig::LoadAgents(const std::string &BaseDirectory, const std::string &BotConfigFile)
 {
-	//	std::string BotConfigFile = Config->GetValue("BotConfigFile");
 	if (BotConfigFile.length() < 1)
 	{
 		return;
@@ -157,6 +156,58 @@ void AgentsConfig::LoadAgents(const std::string &BaseDirectory, const std::strin
 				}
 			}
             
+            std::string OutCmdLine = "";
+            switch (NewBot.Type)
+            {
+            case Python:
+            {
+                OutCmdLine = Config->GetValue("PythonBinary") + " " + NewBot.FileName;
+                break;
+            }
+            case Wine:
+            {
+                OutCmdLine = "wine " + NewBot.FileName;
+                break;
+            }
+            case Mono:
+            {
+                OutCmdLine = "mono " + NewBot.FileName;
+                break;
+            }
+            case DotNetCore:
+            {
+                OutCmdLine = "dotnet " + NewBot.FileName;
+                break;
+            }
+            case CommandCenter:
+            {
+                OutCmdLine = Config->GetValue("CommandCenterPath") + " --ConfigFile " + NewBot.FileName;
+                break;
+            }
+            case BinaryCpp:
+            {
+                OutCmdLine = NewBot.RootPath + NewBot.FileName;
+                break;
+            }
+            case Java:
+            {
+                OutCmdLine = "java -jar " + NewBot.FileName;
+                break;
+            }
+            case NodeJS:
+            {
+                OutCmdLine = Config->GetValue("NodeJSBinary") + " " + NewBot.FileName;
+                break;
+            }
+            case DefaultBot: {} // BlizzardAI - doesn't need any command line arguments
+            }
+
+            if (NewBot.Args != "")
+            {
+                OutCmdLine += " " + NewBot.Args;
+            }
+
+            NewBot.executeCommand = OutCmdLine;
 			BotConfigs.insert(std::make_pair(std::string(NewBot.BotName), NewBot));
 
 		}

--- a/src/sc2laddercore/LadderGame.cpp
+++ b/src/sc2laddercore/LadderGame.cpp
@@ -32,399 +32,14 @@
 #include "Types.h"
 #include "Tools.h"
 #include "LadderGame.h"
-
-
-bool ProcessResponse(const SC2APIProtocol::ResponseCreateGame& response)
-{
-    bool success = true;
-    if (response.has_error()) {
-        std::string errorCode = "Unknown";
-        switch (response.error()) {
-        case SC2APIProtocol::ResponseCreateGame::MissingMap: {
-            errorCode = "Missing Map";
-            break;
-        }
-        case SC2APIProtocol::ResponseCreateGame::InvalidMapPath: {
-            errorCode = "Invalid Map Path";
-            break;
-        }
-        case SC2APIProtocol::ResponseCreateGame::InvalidMapData: {
-            errorCode = "Invalid Map Data";
-            break;
-        }
-        case SC2APIProtocol::ResponseCreateGame::InvalidMapName: {
-            errorCode = "Invalid Map Name";
-            break;
-        }
-        case SC2APIProtocol::ResponseCreateGame::InvalidMapHandle: {
-            errorCode = "Invalid Map Handle";
-            break;
-        }
-        case SC2APIProtocol::ResponseCreateGame::MissingPlayerSetup: {
-            errorCode = "Missing Player Setup";
-            break;
-        }
-        case SC2APIProtocol::ResponseCreateGame::InvalidPlayerSetup: {
-            errorCode = "Invalid Player Setup";
-            break;
-        }
-        default: {
-            break;
-        }
-        }
-
-        std::cerr << "CreateGame request returned an error code: " << errorCode << std::endl;
-        success = false;
-    }
-    if (response.has_error_details() && response.error_details().length() > 0) {
-        std::cerr << "CreateGame request returned error details: " << response.error_details() << std::endl;
-        success = false;
-    }
-    return success;
-
-}
-
-static std::mutex m;
-static std::map<std::string,bool> botCrashed;
-
-void setBotCrashed(const std::string & botName)
-{
-    PrintThread{} << "Crash "<<  botName << std::endl;
-    std::lock_guard<std::mutex> lock(m);
-    botCrashed[botName] = true;
-}
-
-bool getBotCrashed(const std::string & botName)
-{
-    std::lock_guard<std::mutex> lock(m);
-    return botCrashed[botName];
-}
-
-uint32_t getMaxStepTime(const uint32_t gameloop)
-{
-    if (gameloop)
-    {
-        return 5U;  // ToDo: Add this to config file.
-    }
-    return 0U;
-}
-
-SC2APIProtocol::Response* terminateGame(sc2::Connection *client, bool win)
-{
-    sc2::ProtoInterface proto;
-    sc2::GameRequestPtr request = proto.MakeRequest();
-
-    SC2APIProtocol::RequestDebug* debugRequest = request->mutable_debug();
-
-    auto debugCommand = debugRequest->add_debug();
-    auto endGame = debugCommand->mutable_end_game();
-    if (win)
-    {
-        endGame->set_end_result(SC2APIProtocol::DebugEndGame_EndResult::DebugEndGame_EndResult_DeclareVictory);
-    }
-    else
-    {
-        endGame->set_end_result(SC2APIProtocol::DebugEndGame_EndResult::DebugEndGame_EndResult_Surrender);
-    }
-
-    client->Send(request.get());
-    SC2APIProtocol::Response* debugResponse = nullptr;
-    if (client->Receive(debugResponse, 100000))
-    {
-        PrintThread{} << "Received debug end game " << debugResponse->data().DebugString() << std::endl;
-    }
-    return debugResponse;
-}
-
-
-SC2APIProtocol::Response*  doAStep(sc2::Connection *client)
-{
-    sc2::ProtoInterface proto;
-    sc2::GameRequestPtr request = proto.MakeRequest();
-
-    SC2APIProtocol::RequestStep* stepRequest = request->mutable_step();
-
-    stepRequest->set_count(1);
-    client->Send(request.get());
-    SC2APIProtocol::Response* response = nullptr;
-    if (client->Receive(response, 100000))
-    {
-        PrintThread{} << "Received step response " << response->data().DebugString() << std::endl;
-    }
-    return response;
-}
-
-
-//ToDo: proper naming of ExitCase
-ExitCase GameUpdate(sc2::Connection *client, sc2::Server *server, const std::string& botName, const bool debug, uint32_t MaxGameTime, uint32_t MaxRealGameTime, float_t *AvgFrame, uint32_t *GameLoop)
-{
-    if (!client)
-    {
-        PrintThread{} << botName << " : client nullptr." << std::endl;
-        return ExitCase::ClientError;
-    }
-    if (!server)
-    {
-        PrintThread{} << botName << ": server is nullptr" << std::endl;
-        return ExitCase::ServerError;
-    }
-
-    ExitCase CurrentExitCase = ExitCase::InProgress;
-    PrintThread{} << "Starting proxy for " << botName << std::endl;
-    clock_t LastRequest = clock();
-    clock_t FirstRequest = clock();
-    clock_t StepTime = 0;
-    uint32_t currentGameLoop = 0;
-    float_t totalTime = 0;
-    float_t AvgStepTime = 0;
-    std::map<SC2APIProtocol::Status, std::string> status;
-    status[SC2APIProtocol::Status::launched] = "launched";
-    status[SC2APIProtocol::Status::init_game] = "init_game";
-    status[SC2APIProtocol::Status::in_game] = "in_game";
-    status[SC2APIProtocol::Status::in_replay] = "in_replay";
-    status[SC2APIProtocol::Status::ended] = "ended";
-    status[SC2APIProtocol::Status::quit] = "quit";
-    status[SC2APIProtocol::Status::unknown] = "unknown";
-    SC2APIProtocol::Status OldStatus = SC2APIProtocol::Status::unknown;
-    try
-    {
-        bool AlreadyWarned = false;
-        bool AlreadySurrendered = false;
-        SC2APIProtocol::Status CurrentStatus = SC2APIProtocol::Status::init_game;
-        while (CurrentStatus < SC2APIProtocol::Status::in_replay)
-        {
-            // If we know that the bot crashed we surrender for it.
-            if (CurrentExitCase == ExitCase::BotCrashed)
-            {
-                SC2APIProtocol::Response* response = nullptr;
-                // The bot is dead. So we will surrender on its behalf
-                if(!AlreadySurrendered)
-                {
-                    response = terminateGame(client,false);
-                    AlreadySurrendered = true;
-                }
-                // and step the simulation
-                else
-                {
-                    response = doAStep(client);
-                }
-                // until the match has officially ended.
-                CurrentStatus = response->status();
-                if (OldStatus != CurrentStatus)
-                {
-                    PrintThread{} << "New status of " << botName << ": " << status.at(CurrentStatus) << std::endl;
-                    OldStatus = CurrentStatus;
-                }
-                continue;
-            }
-            // Check if the bot thread has send the crashed signal.
-            if (getBotCrashed(botName))
-            {
-                PrintThread{} << botName << " crashed." << std::endl;
-                CurrentExitCase = ExitCase::BotCrashed;
-                continue;
-            }
-
-            if (server->HasRequest())
-            {
-                const sc2::RequestData request = server->PeekRequest();
-                // Analyse request
-                if (request.second)
-                {
-                    if (request.second->has_quit())
-                    {
-						// Intercept quit requests, we want to keep game alive to save replays.
-                        // If a s2client-api (c++) throws an exception a quit request gets issued.
-						PrintThread{} << botName << " HAS ISSUED A QUIT REQUEST. Please tell them not to." << std::endl;
-                        CurrentExitCase = ExitCase::BotCrashed;
-						continue;
-                    }
-                    else if (request.second->has_debug() && !AlreadyWarned)
-                    {
-                        PrintThread{} << botName << " IS USING DEBUG INTERFACE.  POSSIBLE CHEAT! Please tell them not to." << std::endl;
-                        AlreadyWarned = true;
-                    }
-                    else if (StepTime > 0 && request.second->has_step())
-                    {
-                        clock_t ThisStepTime = clock() - StepTime;
-                        totalTime += static_cast<float_t>(ThisStepTime);
-                        AvgStepTime = totalTime / static_cast<float_t>(currentGameLoop);
-                    }
-                }
-                // Send request
-                server->SendRequest(client->connection_);
-
-                // Block for sc2's response then queue it.
-                SC2APIProtocol::Response* response = nullptr;
-                client->Receive(response, 100000);
-                if (response != nullptr)
-                {
-                    if (response->error_size() > 0)
-                    {
-                        PrintThread {} << response->response_case() << std::endl;
-                        std::ostringstream ss;
-                        ss << botName << " : response has " << response->error_size() << "  error(s)!" << std::endl;
-                        for (int i(0); i < response->error_size(); ++i)
-                        {
-                            ss << "\t * " << response->error(i) << std::endl;
-                        }
-                        PrintThread {} << ss.str();
-                        CurrentExitCase = ExitCase::ClientError;
-                    }
-                    if (response->has_observation())
-                    {
-                        CurrentStatus = response->status();
-                        if (OldStatus != CurrentStatus)
-                        {
-                            PrintThread{} << "New status of " << botName << ": " << status.at(CurrentStatus) << std::endl;
-                            OldStatus = CurrentStatus;
-                        }
-                        const SC2APIProtocol::ResponseObservation &LastObservation = response->observation();
-                        const SC2APIProtocol::Observation& ActualObservation = LastObservation.observation();
-                        currentGameLoop = ActualObservation.game_loop();
-                        if (CurrentStatus >= SC2APIProtocol::Status::in_replay && CurrentExitCase == ExitCase::GameTimeout)
-                        {
-                            auto test = response->mutable_observation();
-                            auto test2 = test->add_player_result();
-                            test2->set_result(SC2APIProtocol::Result::Tie);
-                        }
-                        if (MaxGameTime && currentGameLoop > MaxGameTime)
-                        {
-                            terminateGame(client,true);
-                            CurrentExitCase = ExitCase::GameTimeout;
-                        }
-                        if (GameLoop != nullptr)
-                        {
-                            *GameLoop = currentGameLoop;
-                        }
-                    }
-                    else if (response->has_step())
-                    {
-                        StepTime = clock();
-                    }
-                    if (MaxRealGameTime && clock() > (FirstRequest + (MaxRealGameTime * CLOCKS_PER_SEC)))
-                    {
-                        CurrentExitCase = ExitCase::GameTimeout;
-                    }
-
-                }
-
-                // Send the response back to the client.
-                if (!server->connections_.empty() && client->connection_ != nullptr)
-                {
-                    server->QueueResponse(client->connection_, response);
-                    server->SendResponse();
-                }
-                else
-                {
-                    if (server->connections_.empty())
-                    {
-                        PrintThread{} << botName << " server->connections_.empty()" << std::endl;
-                    }
-                    else
-                    {
-                        PrintThread{} << botName << " client->connection_ == nullptr" << std::endl;
-                    }
-                    CurrentExitCase = ExitCase::ClientError;
-                }
-                LastRequest = clock();
-            }
-            else
-            {
-                const uint32_t maxStepTime = getMaxStepTime(currentGameLoop);
-                if (!debug && maxStepTime && (LastRequest + (maxStepTime * CLOCKS_PER_SEC)) < clock())
-                {
-                    PrintThread{} << botName << " is too slow." << std::endl;
-                    CurrentExitCase = ExitCase::BotTimeout;
-                }
-
-                // We can only forward messages to the bot if there is a connection
-                if (server->connections_.empty())
-                {
-                    PrintThread{} << botName << ": server->connections_.empty()" << std::endl;
-                    return ExitCase::ServerError;
-                }
-
-                // If there is no connection to the client it probably crashed.
-                if (client->connection_ == nullptr)
-                {
-                    PrintThread{} << botName << " : lost connection to client" << std::endl;
-                    return ExitCase::ClientError;
-                }
-            }
-        }
-
-        if (CurrentExitCase == ExitCase::InProgress)
-        {
-            CurrentExitCase = ExitCase::GameEnd;
-        }
-        *AvgFrame = AvgStepTime;
-        PrintThread{} << botName << " Exiting with " << GetExitCaseString(CurrentExitCase) << " Average step time " << AvgStepTime << ", total time: " << totalTime << ", game loops: " << currentGameLoop << std::endl;
-        return CurrentExitCase;
-    }
-    catch (const std::exception& e)
-    {
-        PrintThread{} << e.what() << std::endl;
-        return ExitCase::ClientError;
-    }
-}
-
-void ResolveMap(const std::string& map_name, SC2APIProtocol::RequestCreateGame* request, sc2::ProcessSettings process_settings) {
-    // BattleNet map
-    if (!sc2::HasExtension(map_name, ".SC2Map")) {
-        request->set_battlenet_map_name(map_name);
-        return;
-    }
-
-    // Absolute path
-    SC2APIProtocol::LocalMap* local_map = request->mutable_local_map();
-    if (sc2::DoesFileExist(map_name)) {
-        local_map->set_map_path(map_name);
-        return;
-    }
-
-    // Relative path - Game maps directory
-    std::string game_relative = sc2::GetGameMapsDirectory(process_settings.process_path) + map_name;
-    if (sc2::DoesFileExist(game_relative)) {
-        local_map->set_map_path(map_name);
-        return;
-    }
-
-    // Relative path - Library maps directory
-    std::string library_relative = sc2::GetLibraryMapsDirectory() + map_name;
-    if (sc2::DoesFileExist(library_relative)) {
-        local_map->set_map_path(library_relative);
-        return;
-    }
-
-    // Relative path - Remotely saved maps directory
-    local_map->set_map_path(map_name);
-}
-
-sc2::GameRequestPtr CreateStartGameRequest(const std::string &MapName, std::vector<sc2::PlayerSetup> players, sc2::ProcessSettings process_settings)
-{
-    sc2::ProtoInterface proto;
-    sc2::GameRequestPtr request = proto.MakeRequest();
-
-    SC2APIProtocol::RequestCreateGame* request_create_game = request->mutable_create_game();
-    for (const sc2::PlayerSetup& setup : players)
-    {
-        SC2APIProtocol::PlayerSetup* playerSetup = request_create_game->add_player_setup();
-        playerSetup->set_type(SC2APIProtocol::PlayerType(setup.type));
-        playerSetup->set_race(SC2APIProtocol::Race(int(setup.race) + 1));
-        playerSetup->set_difficulty(SC2APIProtocol::Difficulty(setup.difficulty));
-    }
-    ResolveMap(MapName, request_create_game, process_settings);
-
-    request_create_game->set_realtime(false);
-    return request;
-}
+#include "Proxy.h"
 
 
 void LadderGame::LogStartGame(const BotConfig &Bot1, const BotConfig &Bot2)
 {
     std::time_t t = std::time(nullptr);
     std::tm tm = *std::localtime(&t);
+    // Why do we log this in stderr ?
     std::string Bot1Filename = Bot1.RootPath + "/stderr.log";
     std::string Bot2Filename = Bot2.RootPath + "/stderr.log";
     std::ofstream outfile;
@@ -437,618 +52,95 @@ void LadderGame::LogStartGame(const BotConfig &Bot1, const BotConfig &Bot2)
 }
 
 
-bool LadderGame::SaveReplay(sc2::Connection *client, const std::string& path) {
-    sc2::ProtoInterface proto;
-    sc2::GameRequestPtr request = proto.MakeRequest();
-    request->mutable_save_replay();
-    SendDataToConnection(client, request.get());
-    SC2APIProtocol::Response* replay_response = nullptr;
-    if (!client->Receive(replay_response, 10000))
-    {
-        //        std::cout << "Failed to receive replay response" << std::endl;
-        return false;
-    }
-
-    const SC2APIProtocol::ResponseSaveReplay& response_replay = replay_response->save_replay();
-
-    if (response_replay.data().size() == 0) {
-        return false;
-    }
-
-    std::ofstream file;
-    file.open(path, std::fstream::binary);
-    if (!file.is_open()) {
-        return false;
-    }
-
-    file.write(&response_replay.data()[0], response_replay.data().size());
-    return true;
-}
-
-bool LadderGame::ProcessObservationResponse(SC2APIProtocol::ResponseObservation Response, std::vector<sc2::PlayerResult> *PlayerResults)
-{
-    if (Response.player_result_size())
-    {
-        PlayerResults->clear();
-        for (const auto& player_result : Response.player_result()) {
-            PlayerResults->push_back(sc2::PlayerResult(player_result.player_id(), sc2::ConvertGameResultFromProto(player_result.result())));
-        }
-        return true;
-    }
-    return false;
-}
-
-std::string LadderGame::GetBotCommandLine(const BotConfig &AgentConfig, int GamePort, int StartPort, const std::string &OpponentId, bool CompOpp, sc2::Race CompRace, sc2::Difficulty CompDifficulty)
-{
-    // Add bot type specific command line needs
-    std::string OutCmdLine;
-    switch (AgentConfig.Type)
-    {
-    case Python:
-    {
-        OutCmdLine = Config->GetValue("PythonBinary") + " " + AgentConfig.FileName;
-        break;
-    }
-    case Wine:
-    {
-        OutCmdLine = "wine " + AgentConfig.FileName;
-        break;
-    }
-    case Mono:
-    {
-        OutCmdLine = "mono " + AgentConfig.FileName;
-        break;
-    }
-    case DotNetCore:
-    {
-        OutCmdLine = "dotnet " + AgentConfig.FileName;
-        break;
-    }
-    case CommandCenter:
-    {
-        OutCmdLine = Config->GetValue("CommandCenterPath") + " --ConfigFile " + AgentConfig.FileName;
-        break;
-    }
-    case BinaryCpp:
-    {
-        OutCmdLine = AgentConfig.RootPath + AgentConfig.FileName;
-        break;
-    }
-    case Java:
-    {
-        OutCmdLine = "java -jar " + AgentConfig.FileName;
-        break;
-    }
-    case NodeJS:
-    {
-        OutCmdLine = Config->GetValue("NodeJSBinary") + " " + AgentConfig.FileName;
-        break;
-    }
-    case DefaultBot: {} // BlizzardAI - doesn't need any command line arguments
-    }
-
-    // Add universal arguments
-    OutCmdLine += " --GamePort " + std::to_string(GamePort) + " --StartPort " + std::to_string(StartPort) + " --LadderServer 127.0.0.1 --OpponentId " + OpponentId;
-
-    if (CompOpp)
-    {
-        OutCmdLine += " --ComputerOpponent 1 --ComputerRace " + GetRaceString(CompRace) + " --ComputerDifficulty " + GetDifficultyString(CompDifficulty);
-    }
-    if (AgentConfig.Args != "")
-    {
-        OutCmdLine += " " + AgentConfig.Args;
-    }
-    return OutCmdLine;
-}
-
-
-void LadderGame::ResolveMap(const std::string& map_name, SC2APIProtocol::RequestCreateGame* request, sc2::ProcessSettings process_settings) {
-    // BattleNet map
-    if (!sc2::HasExtension(map_name, ".SC2Map")) {
-        request->set_battlenet_map_name(map_name);
-        return;
-    }
-
-    // Absolute path
-    SC2APIProtocol::LocalMap* local_map = request->mutable_local_map();
-    if (sc2::DoesFileExist(map_name)) {
-        local_map->set_map_path(map_name);
-        return;
-    }
-
-    // Relative path - Game maps directory
-    std::string game_relative = sc2::GetGameMapsDirectory(process_settings.process_path) + map_name;
-    if (sc2::DoesFileExist(game_relative)) {
-        local_map->set_map_path(map_name);
-        return;
-    }
-
-    // Relative path - Library maps directory
-    std::string library_relative = sc2::GetLibraryMapsDirectory() + map_name;
-    if (sc2::DoesFileExist(library_relative)) {
-        local_map->set_map_path(library_relative);
-        return;
-    }
-
-    // Relative path - Remotely saved maps directory
-    local_map->set_map_path(map_name);
-}
-
-sc2::GameRequestPtr LadderGame::CreateStartGameRequest(const std::string &MapName, std::vector<sc2::PlayerSetup> players, sc2::ProcessSettings process_settings)
-{
-    sc2::ProtoInterface proto;
-    sc2::GameRequestPtr request = proto.MakeRequest();
-
-    SC2APIProtocol::RequestCreateGame* request_create_game = request->mutable_create_game();
-    for (const sc2::PlayerSetup& setup : players)
-    {
-        SC2APIProtocol::PlayerSetup* playerSetup = request_create_game->add_player_setup();
-        playerSetup->set_type(SC2APIProtocol::PlayerType(setup.type));
-        playerSetup->set_race(SC2APIProtocol::Race(int(setup.race) + 1));
-        playerSetup->set_difficulty(SC2APIProtocol::Difficulty(setup.difficulty));
-    }
-    ResolveMap(MapName, request_create_game, process_settings);
-
-    request_create_game->set_realtime(false);
-    return request;
-}
-
-sc2::GameResponsePtr LadderGame::CreateErrorResponse()
-{
-    const sc2::GameResponsePtr response = std::make_shared<SC2APIProtocol::Response>(SC2APIProtocol::Response());
-    return response;
-}
-
-sc2::GameRequestPtr LadderGame::CreateLeaveGameRequest()
-{
-    sc2::ProtoInterface proto;
-    sc2::GameRequestPtr request = proto.MakeRequest();
-
-    request->mutable_leave_game();
-
-    return request;
-}
-
-sc2::GameRequestPtr LadderGame::CreateQuitRequest()
-{
-    sc2::ProtoInterface proto;
-    sc2::GameRequestPtr request = proto.MakeRequest();
-    request->mutable_quit();
-
-    return request;
-}
-
-
-bool LadderGame::SendDataToConnection(sc2::Connection *Connection, const SC2APIProtocol::Request *request)
-{
-    if (Connection->connection_ != nullptr)
-    {
-        Connection->Send(request);
-        return true;
-    }
-    return false;
-}
-
-
-ResultType LadderGame::GetPlayerResults(sc2::Connection *client)
-{
-    if (client == nullptr)
-    {
-        return ResultType::ProcessingReplay;
-    }
-    sc2::ProtoInterface proto;
-    sc2::GameRequestPtr ObservationRequest = proto.MakeRequest();
-    ObservationRequest->mutable_observation();
-    SendDataToConnection(client, ObservationRequest.get());
-
-    SC2APIProtocol::Response* ObservationResponse = nullptr;
-    std::vector<sc2::PlayerResult> PlayerResults;
-    if (client->Receive(ObservationResponse, 10000))
-    {
-        ProcessObservationResponse(ObservationResponse->observation(), &PlayerResults);
-    }
-    if (PlayerResults.size() > 1)
-    {
-        if (PlayerResults.back().result == sc2::GameResult::Undecided)
-        {
-            return ResultType::ProcessingReplay;
-        }
-        else if (PlayerResults.back().result == sc2::GameResult::Tie)
-        {
-            return ResultType::Tie;
-        }
-        else if (PlayerResults.back().result == sc2::GameResult::Win)
-        {
-            if (PlayerResults.back().player_id == 1)
-            {
-                return ResultType::Player1Win;
-            }
-            else
-            {
-                return ResultType::Player2Win;
-            }
-        }
-        else if (PlayerResults.back().result == sc2::GameResult::Loss)
-        {
-            if (PlayerResults.back().player_id == 1)
-            {
-                return ResultType::Player2Win;
-            }
-            else
-            {
-                return ResultType::Player1Win;
-            }
-
-        }
-    }
-    return ResultType::ProcessingReplay;
-}
-
 GameResult LadderGame::StartGameVsDefault(const BotConfig &Agent1, sc2::Race CompRace, sc2::Difficulty CompDifficulty, const std::string &Map)
 {
     PrintThread{} << " THIS FEATURE WAS NOT MAINTAINED FOR A LONG TIME AND IS PROBABLY BROKEN. SORRY" << std::endl;
-    std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
-    std::string ReplayFile = ReplayDir + Agent1.BotName + "v" + GetDifficultyString(CompDifficulty) + "-" + RemoveMapExtension(Map) + ".Sc2Replay";
-    ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
-    remove(ReplayFile.c_str());
-    using namespace std::chrono_literals;
-    // Setup server that mimicks sc2.
-    std::string Agent1Path = GetBotCommandLine(Agent1, 5677, PORT_START, "", true, sc2::Race::Random, CompDifficulty);
-    if (Agent1Path == "")
-    {
-        return GameResult();
-    }
 
-    sc2::Server server;
-
-    server.Listen("5677", "100000", "100000", "5");
-
-    // Find game executable and run it.
-    sc2::ProcessSettings process_settings;
-    sc2::GameSettings game_settings;
-    sc2::ParseSettings(CoordinatorArgc, CoordinatorArgv, process_settings, game_settings);
-    uint64_t BotProcessId = sc2::StartProcess(process_settings.process_path,
-        { "-listen", "127.0.0.1",
-          "-port", "5679",
-          "-displayMode", "0",
-          "-dataVersion", process_settings.data_version }
-    );
-
-    // Connect to running sc2 process.
-    sc2::Connection client;
-    client.Connect("127.0.0.1", 5679, false);
-    int connectionAttemptsClient = 0;
-    while (!client.Connect("127.0.0.1", 5679, false))
-    {
-        connectionAttemptsClient++;
-        sc2::SleepFor(1000);
-        if (connectionAttemptsClient > 60)
-        {
-            PrintThread{} << "Failed to connect client 1. BotProcessID: " << BotProcessId << std::endl;
-            return GameResult();
-        }
-    }
-
-    std::vector<sc2::PlayerSetup> Players;
-    Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent1.Race, nullptr, sc2::Easy));
-    Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Computer, sc2::Race::Random, nullptr, CompDifficulty));
-    sc2::GameRequestPtr Create_game_request = CreateStartGameRequest(Map, Players, process_settings);
-    SendDataToConnection(&client, Create_game_request.get());
-
-    SC2APIProtocol::Response* create_response = nullptr;
-    if (client.Receive(create_response, 100000))
-    {
-        PrintThread{} << "Recieved create game response " << create_response->data().DebugString() << std::endl;
-        if (ProcessResponse(create_response->create_game()))
-        {
-            PrintThread{} << "Create game successful" << std::endl << std::endl;
-        }
-    }
-    unsigned long ProcessId;
-    auto bot1ProgramThread = std::thread(StartBotProcess, Agent1, Agent1Path, &ProcessId);
-    sc2::SleepFor(1000);
-
-    PrintThread{} << "Monitoring client of: " << Agent1.BotName << std::endl;
-    float_t AvgFrameTime = 0;
-    uint32_t GameLoop = 0U;
-    auto bot1UpdateThread = std::async(GameUpdate, &client, &server, Agent1.BotName, Agent1.Debug, MaxGameTime, MaxRealGameTime, &AvgFrameTime, &GameLoop);
-    sc2::SleepFor(1000);
-
-    ResultType CurrentResult = ResultType::InitializationError;
-    bool GameRunning = true;
-    //sc2::ProtoInterface proto_1;
-    //std::vector<sc2::PlayerResult> Player1Results;
-    SleepFor(10000);
-    while (GameRunning)
-    {
-
-        auto update1status = bot1UpdateThread.wait_for(1s);
-        if (update1status == std::future_status::ready)
-        {
-            ExitCase BotExitCase = bot1UpdateThread.get();
-            if (BotExitCase == ExitCase::BotCrashed)
-            {
-                CurrentResult = ResultType::Player1Crash;
-            }
-            else if (BotExitCase == ExitCase::GameTimeout)
-            {
-                CurrentResult = ResultType::Timeout;
-            }
-            else
-            {
-                CurrentResult = ResultType::ProcessingReplay;
-            }
-
-            GameRunning = false;
-            break;
-        }
-    }
-    if (CurrentResult == ResultType::ProcessingReplay)
-    {
-        CurrentResult = GetPlayerResults(&client);
-    }
-
-
-    SaveReplay(&client, ReplayFile);
-    if (!SendDataToConnection(&client, CreateLeaveGameRequest().get()))
-    {
-        PrintThread{} << "CreateLeaveGameRequest failed" << std::endl;
-    }
-
-    bot1ProgramThread.join();
-    GameResult result;
-    result.Result = CurrentResult;
-    return result;
+    return GameResult();
 }
 
 GameResult LadderGame::StartGame(const BotConfig &Agent1, const BotConfig &Agent2, const std::string &Map)
 {
-    using namespace std::chrono_literals;
-    // Setup server that mimicks sc2.
-    std::string Agent1Path = GetBotCommandLine(Agent1, 5677, PORT_START, Agent2.PlayerId);
-    std::string Agent2Path = GetBotCommandLine(Agent2, 5678, PORT_START, Agent1.PlayerId);
-    if (Agent1Path == "" || Agent2Path == "")
-    {
-        return GameResult();
-    }
-    sc2::Server server;
-    sc2::Server server2;
-    server.Listen("5677", "100000", "100000", "5");
-    server2.Listen("5678", "100000", "100000", "5");
-    // Find game executable and run it.
+    // Proxy init
+    Proxy proxyBot1(MaxGameTime, MaxRealGameTime, Agent1);
+    Proxy proxyBot2(MaxGameTime, MaxRealGameTime, Agent2);
+
+    // Start the SC2 instances
     sc2::ProcessSettings process_settings;
     sc2::GameSettings game_settings;
     sc2::ParseSettings(CoordinatorArgc, CoordinatorArgv, process_settings, game_settings);
-    auto GameClientPid1 = sc2::StartProcess(process_settings.process_path,
-        { "-listen", "127.0.0.1",
-          "-port", "5679",
-          "-displayMode", "0",
-          "-dataVersion", process_settings.data_version }
-    );
-    auto GameClientPid2 = sc2::StartProcess(process_settings.process_path,
-        { "-listen", "127.0.0.1",
-          "-port", "5680",
-          "-displayMode", "0",
-          "-dataVersion", process_settings.data_version }
-    );
-
-    // Connect to running sc2 process.
-    sc2::Connection client;
-    int connectionAttemptsClient1 = 0;
-    while (!client.Connect("127.0.0.1", 5679, false))
+    (void) game_settings;
+    constexpr int portServerBot1 = 5677;
+    constexpr int portServerBot2 = 5678;
+    constexpr int portClientBot1 = 5679;
+    constexpr int portClientBot2 = 5680;
+    PrintThread {} << "Starting the StarCraft II clients." << std::endl;
+    const bool startSC2InstanceSuccessful1 = proxyBot1.startSC2Instance(process_settings, portServerBot1, portClientBot1);
+    const bool startSC2InstanceSuccessful2 = proxyBot2.startSC2Instance(process_settings, portServerBot2, portClientBot2);
+    if (!startSC2InstanceSuccessful1 || !startSC2InstanceSuccessful2)
     {
-        connectionAttemptsClient1++;
+        PrintThread {} << "Failed to start the StarCraft II clients." << std::endl;
+        return GameResult();
+    }
+
+    // Setup map
+    // toDo: RealTimeMode?
+    PrintThread {} << "Creating the game on " << Map << "." << std::endl;
+    const bool setupGameSuccessful1 = proxyBot1.setupGame(process_settings, Map, false, Agent1.Race, Agent2.Race);
+    const bool setupGameSuccessful2 = proxyBot2.setupGame(process_settings, Map, false, Agent1.Race, Agent2.Race);
+    if (!setupGameSuccessful1 || !setupGameSuccessful2)
+    {
+        PrintThread {} << "Failed to create the game." << std::endl;
+        return GameResult();
+    }
+
+    // Start the bots
+    PrintThread {} << "Starting the bots " << Agent1.BotName << " and " << Agent2.BotName << "." << std::endl;
+    const bool startBotSuccessful1 = proxyBot1.startBot(portServerBot1, PORT_START, Agent2.PlayerId);
+    const bool startBotSuccessful2 = proxyBot2.startBot(portServerBot2, PORT_START, Agent1.PlayerId);
+    if (!startBotSuccessful1)
+    {
+        PrintThread {} << "Failed to start " << Agent1.BotName << "." << std::endl;
+    }
+    if (!startBotSuccessful2)
+    {
+        PrintThread {} << "Failed to start " << Agent2.BotName << "." << std::endl;
+    }
+    if (!startBotSuccessful1 || !startBotSuccessful2)
+    {
+        return GameResult();
+    }
+
+    // Start the match
+    PrintThread {} << "Starting the match." << std::endl;
+    proxyBot1.startGame();
+    proxyBot2.startGame();
+
+    // Check from time to time if the match finished
+    while (!proxyBot1.gameFinished() || !proxyBot2.gameFinished())
+    {
         sc2::SleepFor(1000);
-        if (connectionAttemptsClient1 > 60)
-        {
-            PrintThread{} << "Failed to connect client 1. ClientProcessID: " << GameClientPid1 << std::endl;
-            return GameResult();
-        }
-    }
-    sc2::Connection client2;
-    int connectionAttemptsClient2 = 0;
-    while (!client2.Connect("127.0.0.1", 5680, false))
-    {
-        connectionAttemptsClient2++;
-        sc2::SleepFor(1000);
-        if (connectionAttemptsClient2 > 60)
-        {
-            PrintThread{} << "Failed to connect client 2. ClientProcessID: " << GameClientPid2 << std::endl;
-            return GameResult();
-        }
     }
 
-    std::vector<sc2::PlayerSetup> Players;
+    std::string replayDir = Config->GetValue("LocalReplayDirectory");
+    std::string replayFile = replayDir + Agent1.BotName + "v" + Agent2.BotName + "-" + RemoveMapExtension(Map) + ".SC2Replay";
+    replayFile.erase(remove_if(replayFile.begin(), replayFile.end(), isspace), replayFile.end());
+    if (!(proxyBot1.saveReplay(replayFile) || proxyBot2.saveReplay(replayFile)))
+    {
+        PrintThread{} << "Saving replay failed." << std::endl;
+    }
+    ChangeBotNames(replayFile, Agent1.BotName, Agent2.BotName);
 
-    Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent1.Race, nullptr, sc2::Easy));
-    Players.push_back(sc2::PlayerSetup(sc2::PlayerType::Participant, Agent2.Race, nullptr, sc2::Easy));
-    sc2::GameRequestPtr Create_game_request = CreateStartGameRequest(Map, Players, process_settings);
-    client.Send(Create_game_request.get());
-    SC2APIProtocol::Response* create_response = nullptr;
-    if (client.Receive(create_response, 100000))
-    {
-        if (create_response->has_create_game())
-        {
-            PrintThread{} << "Received create game response " << create_response->data().DebugString() << std::endl;
-            if (ProcessResponse(create_response->create_game()))
-            {
-                PrintThread{} << "Create game successful" << std::endl << std::endl;
-            }
-            else
-            {
-                //TODO: DO SOMETHING
-            }
-        }
-        else
-        {
-            PrintThread{} << "Got wrong kind of response." << std::endl;
-            //TODO: DO SOMETHING
-        }
-    }
-    // Bots
-    unsigned long Bot1ThreadId = 0;
-    unsigned long Bot2ThreadId = 0;
-    LogStartGame(Agent1, Agent2);
-    botCrashed={{Agent1.BotName, false},{Agent2.BotName, false}};
-    auto bot1ProgramThread = std::async(std::launch::async, &StartBotProcess, Agent1, Agent1Path, &Bot1ThreadId);
-    auto bot2ProgramThread = std::async(std::launch::async, &StartBotProcess, Agent2, Agent2Path, &Bot2ThreadId);
-    sc2::SleepFor(2000);
-    if (bot1ProgramThread.wait_for(0s) == std::future_status::ready)
-    {
-        setBotCrashed(Agent1.BotName);
-    }
-    if (bot2ProgramThread.wait_for(0s) == std::future_status::ready)
-    {
-        setBotCrashed(Agent2.BotName);
-    }
-    if (getBotCrashed(Agent1.BotName) && getBotCrashed(Agent2.BotName))
-    {
-        // something is seriously wrong. Do something.
-    }
-    // Proxies
-    float_t Bot1AvgFrame = 0;
-    float_t Bot2AvgFrame = 0;
-    uint32_t GameLoop = 0U;
-    auto bot1UpdateThread = std::async(std::launch::async, &GameUpdate, &client, &server, Agent1.BotName, Agent1.Debug, MaxGameTime, MaxRealGameTime, &Bot1AvgFrame, &GameLoop);
-    auto bot2UpdateThread = std::async(std::launch::async, &GameUpdate, &client2, &server2, Agent2.BotName, Agent2.Debug, MaxGameTime, MaxRealGameTime, &Bot2AvgFrame, nullptr);
-    sc2::SleepFor(1000);
-    ResultType CurrentResult = ResultType::InitializationError;
-    bool GameRunning = true;
-    while (GameRunning)
-    {
-        auto update1status = bot1UpdateThread.wait_for(1s);
-        auto update2status = bot2UpdateThread.wait_for(0ms);
-        auto thread1Status = bot1ProgramThread.wait_for(0ms);
-        auto thread2Status = bot2ProgramThread.wait_for(0ms);
-        if (update1status == std::future_status::ready)
-        {
-            ExitCase BotExitCase = bot1UpdateThread.get();
-            if (BotExitCase == ExitCase::BotCrashed)
-            {
-                CurrentResult = ResultType::Player1Crash;
-            }
-            else if (BotExitCase == ExitCase::GameTimeout)
-            {
-                CurrentResult = ResultType::Timeout;
-            }
-            else
-            {
-                CurrentResult = ResultType::ProcessingReplay;
-            }
-
-            GameRunning = false;
-            break;
-        }
-        if (update2status == std::future_status::ready)
-        {
-            ExitCase BotExitCase = bot2UpdateThread.get();
-            if (BotExitCase == ExitCase::BotCrashed)
-            {
-                CurrentResult = ResultType::Player2Crash;
-            }
-            else if (BotExitCase == ExitCase::GameTimeout)
-            {
-                CurrentResult = ResultType::Timeout;
-            }
-            else
-            {
-                CurrentResult = ResultType::ProcessingReplay;
-            }
-
-            GameRunning = false;
-            break;
-        }
-        if (thread1Status == std::future_status::ready)
-        {
-            setBotCrashed(Agent1.BotName);
-            CurrentResult = ResultType::Player1Crash;
-            GameRunning = false;
-        }
-        if (thread2Status == std::future_status::ready)
-        {
-            setBotCrashed(Agent2.BotName);
-            CurrentResult = ResultType::Player2Crash;
-            GameRunning = false;
-        }
-    }
-    PrintThread{} << "Hm?" << std::endl;
-    if (bot1UpdateThread.wait_for(0ms) != std::future_status::ready)
-    {
-        PrintThread{} << "Waiting for "<<  Agent1.BotName << std::endl;
-        bot1UpdateThread.wait();
-        PrintThread{} << "Game ended for "<<  Agent1.BotName << std::endl;
-    }
-    if (bot2UpdateThread.wait_for(0ms) != std::future_status::ready)
-    {
-        PrintThread{} << "Waiting for " << Agent2.BotName << std::endl;
-        bot2UpdateThread.wait();
-        PrintThread{} << "Game ended for " << Agent2.BotName << std::endl;
-    }
-
-    PrintThread{} << "Hm?" << std::endl;
-
-    if (CurrentResult == ResultType::ProcessingReplay)
-    {
-        CurrentResult = GetPlayerResults(&client);
-    }
-    if (CurrentResult == ResultType::ProcessingReplay)
-    {
-        CurrentResult = GetPlayerResults(&client2);
-    }
-    sc2::SleepFor(1000);
-    PrintThread{} << "Saving replay" << std::endl;
-    std::string ReplayDir = Config->GetValue("LocalReplayDirectory");
-    std::string ReplayFile = ReplayDir + Agent1.BotName + "v" + Agent2.BotName + "-" + RemoveMapExtension(Map) + ".SC2Replay";
-    ReplayFile.erase(remove_if(ReplayFile.begin(), ReplayFile.end(), isspace), ReplayFile.end());
-    if (!SaveReplay(&client, ReplayFile))
-    {
-        SaveReplay(&client2, ReplayFile);
-    }
-    sc2::SleepFor(1000);
-    ChangeBotNames(ReplayFile, Agent1.BotName, Agent2.BotName);
-    sc2::SleepFor(1000);
-    if (!server.connections_.empty())
-    {
-        PrintThread{} << Agent1.BotName << " is still connected..." << std::endl;
-    }
-    if (!server2.connections_.empty())
-    {
-        PrintThread{} << Agent2.BotName << " is still connected..." << std::endl;
-    }
-    std::future_status bot1ProgStatus = std::future_status::deferred;
-    std::future_status bot2ProgStatus = std::future_status::deferred;
-    auto start = std::chrono::system_clock::now();
-    std::chrono::duration<double> elapsed_seconds;
-    while (elapsed_seconds.count() < 20)
-    {
-        bot1ProgStatus = bot1ProgramThread.wait_for(50ms);
-        bot2ProgStatus = bot2ProgramThread.wait_for(50ms);
-        if (bot1ProgStatus == std::future_status::ready && bot2ProgStatus == std::future_status::ready)
-        {
-            PrintThread{} << "Both bots quit properly." << std::endl;
-            break;
-        }
-        elapsed_seconds = std::chrono::system_clock::now() - start;
-    }
-    if (bot1ProgStatus != std::future_status::ready)
-    {
-        PrintThread{} << "Failed to detect end of " << Agent1.BotName << " after 20s. Make sure the bot does not issue leaveGame or quit. Killing" << std::endl;
-        KillBotProcess(Bot1ThreadId);
-    }
-    if (bot2ProgStatus != std::future_status::ready)
-    {
-        PrintThread{} << "Failed to detect end of " << Agent2.BotName << " after 20s. Make sure the bot does not issue leaveGame or quit. Killing" << std::endl;
-        KillBotProcess(Bot2ThreadId);
-    }
-    sc2::SleepFor(1000);
-    sc2::TerminateProcess(GameClientPid1);
-    sc2::TerminateProcess(GameClientPid2);
-    sc2::SleepFor(1000);
     GameResult Result;
-    Result.Result = CurrentResult;
-    Result.Bot1AvgFrame = Bot1AvgFrame;
-    Result.Bot2AvgFrame = Bot2AvgFrame;
-    Result.GameLoop = GameLoop;
+    const auto resultBot1 = proxyBot1.getResult();
+    const auto resultBot2 = proxyBot2.getResult();
+
+    PrintThread{} << "result " << Agent1.BotName << " : " << GetExitCaseString(resultBot1) << ", result " << Agent2.BotName << " : " << GetExitCaseString(resultBot2) << std::endl;
+
+    Result.Result = getEndResultFromProxyResults(resultBot1, resultBot2);
+    Result.Bot1AvgFrame = proxyBot1.stats().avgLoopDuration;
+    Result.Bot2AvgFrame = proxyBot1.stats().avgLoopDuration;
+    Result.GameLoop = proxyBot1.stats().gameLoops;
 
     std::time_t t = std::time(nullptr);
     std::tm tm = *std::gmtime(&t);

--- a/src/sc2laddercore/LadderGame.h
+++ b/src/sc2laddercore/LadderGame.h
@@ -12,23 +12,12 @@ class LadderGame
 public:
     LadderGame(int InCoordinatorArgc, char** InCoordinatorArgv, LadderConfig *InConfig);
     GameResult StartGame(const BotConfig & Agent1, const BotConfig & Agent2, const std::string & Map);
-    GameResult StartGameVsDefault(const BotConfig &Agent1, sc2::Race CompRace, sc2::Difficulty CompDifficulty, const std::string &Map);
 
 
 
 private:
     void LogStartGame(const BotConfig & Bot1, const BotConfig & Bot2);
-    bool SaveReplay(sc2::Connection * client, const std::string & path);
-    bool ProcessObservationResponse(SC2APIProtocol::ResponseObservation Response, std::vector<sc2::PlayerResult>* PlayerResults);
-    std::string GetBotCommandLine(const BotConfig &AgentConfig, int GamePort, int StartPort, const std::string &OpponentId, bool CompOpp = false, sc2::Race CompRace = sc2::Race::Terran, sc2::Difficulty CompDifficulty = sc2::Difficulty::Easy);
-    void ResolveMap(const std::string & map_name, SC2APIProtocol::RequestCreateGame * request, sc2::ProcessSettings process_settings);
-    sc2::GameRequestPtr CreateStartGameRequest(const std::string & MapName, std::vector<sc2::PlayerSetup> players, sc2::ProcessSettings process_settings);
-    sc2::GameResponsePtr CreateErrorResponse();
-    sc2::GameRequestPtr CreateLeaveGameRequest();
-    sc2::GameRequestPtr CreateQuitRequest();
-    ResultType GetPlayerResults(sc2::Connection * client);
-    bool SendDataToConnection(sc2::Connection * Connection, const SC2APIProtocol::Request * request);
-    void ChangeBotNames(const std::string ReplayFile, const std::string &Bot1Name, const std::string Bot2Name);
+    void ChangeBotNames(const std::string &ReplayFile, const std::string &Bot1Name, const std::string &Bot2Name);
 
     int CoordinatorArgc;
     char** CoordinatorArgv;

--- a/src/sc2laddercore/LadderManager.cpp
+++ b/src/sc2laddercore/LadderManager.cpp
@@ -145,21 +145,23 @@ void LadderManager::SaveJsonResult(const BotConfig &Bot1, const BotConfig &Bot2,
 	NewResult.AddMember("Bot2", Bot2.BotName, alloc);
 	switch (Result.Result)
 	{
-	case Player1Win:
-	case Player2Crash:
+    case ResultType::Player1Win:
+    case ResultType::Player2Crash:
+    case ResultType::Player2TimeOut:
 		NewResult.AddMember("Winner", Bot1.BotName, alloc);
 		break;
-	case Player2Win:
-	case Player1Crash:
+    case ResultType::Player2Win:
+    case ResultType::Player1Crash:
+    case ResultType::Player1TimeOut:
 		NewResult.AddMember("Winner", Bot2.BotName, alloc);
 		break;
-	case Tie:
-	case Timeout:
+    case ResultType::Tie:
+    case ResultType::Timeout:
 		NewResult.AddMember("Winner", "Tie", alloc);
 		break;
-	case InitializationError:
-	case Error:
-	case ProcessingReplay:
+    case ResultType::InitializationError:
+    case ResultType::Error:
+    case ResultType::ProcessingReplay:
 		NewResult.AddMember("Winner", "Error", alloc);
 		break;
 	}
@@ -512,5 +514,14 @@ std::string LadderManager::getSC2Path() const
 	sc2::ProcessSettings process_settings;
 	sc2::GameSettings game_settings;
 	sc2::ParseSettings(CoordinatorArgc, CoordinatorArgv, process_settings, game_settings);
+    PrintThread{} << " test " << process_settings.process_path << std::endl;
+    if (process_settings.process_path.empty())
+    {
+        PrintThread{} << "Error: Could not detect StarCraft II executable." << std::endl;
+    }
+    if (!sc2::DoesFileExist(process_settings.process_path))
+    {
+        PrintThread{} << "Error: Could not detect StarCraft II executable at " << process_settings.process_path << std::endl;
+    }
 	return process_settings.process_path;
 }

--- a/src/sc2laddercore/MatchupList.cpp
+++ b/src/sc2laddercore/MatchupList.cpp
@@ -31,6 +31,11 @@ MatchupList::MatchupList(const std::string &inMatchupListFile, AgentsConfig *InA
 	, ServerUsername(InServerUsername)
 	, ServerPassword(InServerPassword)
 {
+    // Do not create matches if we can not run them.
+    if (sc2Path.empty() || !sc2::DoesFileExist(sc2Path))
+    {
+        return;
+    }
 	MatchUpProcess = GetMatchupListTypeFromString(GeneratorType);
 	if(MatchUpProcess == MatchupListType::None)
 	{
@@ -47,7 +52,7 @@ bool MatchupList::GenerateMatches(std::vector<std::string> &&maps)
 	PrintThread{} << "Found agents: " << std::endl;
 	for (const auto &Agent : AgentConfig->BotConfigs)
 	{
-		PrintThread{} << Agent.second.BotName << std::endl;
+        PrintThread{} << "* " << Agent.second.BotName << std::endl;
 	}
 	const auto firstInvalidMapIt = std::remove_if(maps.begin(),maps.end(),[&](const auto& map)->bool { return !isMapAvailable(map, sc2Path);});
 	if (firstInvalidMapIt != maps.cbegin())

--- a/src/sc2laddercore/MatchupList.cpp
+++ b/src/sc2laddercore/MatchupList.cpp
@@ -182,7 +182,7 @@ bool MatchupList::LoadMatchupList()
 		}
 		if (!AgentConfig->FindBot(SecondAgent, Agent2))
 		{
-			PrintThread{} << "Unable to find agent: " + FirstAgent << std::endl;
+			PrintThread{} << "Unable to find agent: " + SecondAgent << std::endl;
 			continue;
 		}
 		if (!isMapAvailable(Map,sc2Path))

--- a/src/sc2laddercore/Proxy.cpp
+++ b/src/sc2laddercore/Proxy.cpp
@@ -1,0 +1,716 @@
+#include "Proxy.h"
+#include "Tools.h"
+#include "sc2utils/sc2_manage_process.h"
+
+#include <fstream>
+
+using namespace std::chrono_literals;
+
+bool Proxy::m_mapAlreadyLoaded{false};
+
+Proxy::Proxy(const uint32_t maxGameLoops,const uint32_t maxRealGameTime, const BotConfig& botConfig):
+    m_maxGameLoops(maxGameLoops)
+  , m_maxRealGameTime(maxRealGameTime)
+  , m_botConfig(botConfig)
+{ }
+
+Proxy::~Proxy()
+{
+    // Set it false for the match after this one.
+    m_mapAlreadyLoaded = false;
+
+    // Check if the bot is still running.
+    auto start = std::chrono::system_clock::now();
+    std::chrono::duration<double> elapsed_seconds{0};
+    std::future_status botProgStatus{std::future_status::deferred};
+    //toDo: add to config
+    constexpr auto maxWaitTime{20};
+    if (m_botProgramThread.valid())
+    {
+        while (elapsed_seconds.count() < maxWaitTime)
+        {
+            botProgStatus = m_botProgramThread.wait_for(1s);
+            if (botProgStatus == std::future_status::ready)
+            {
+                PrintThread{} << m_botConfig.BotName << " : Bot terminated properly." << std::endl;
+                break;
+            }
+            elapsed_seconds = std::chrono::system_clock::now() - start;
+        }
+        if (botProgStatus != std::future_status::ready)
+        {
+            PrintThread{} << m_botConfig.BotName << " : Bot is still running after " << maxWaitTime << " seconds. Sending kill signal." << std::endl;
+            KillBotProcess(m_botThreadId);
+        }
+        sc2::SleepFor(5000);
+    }
+    if (m_gameClientPid)
+    {
+        if (!sc2::TerminateProcess(m_gameClientPid))
+        {
+            PrintThread{} << m_botConfig.BotName << " : Terminating SC2 failed!" << std::endl;
+        }
+        sc2::SleepFor(5000);
+    }
+}
+
+bool Proxy::startSC2Instance(const sc2::ProcessSettings& processSettings, const int portServer, const int portClient)
+{
+    // magic numbers
+    m_server.Listen(std::to_string(portServer).c_str(), "100000", "100000", "5");
+
+    m_gameClientPid = sc2::StartProcess(processSettings.process_path,
+    { "-listen", m_localHost,
+      "-port", std::to_string(portClient),
+      "-displayMode", "0",
+      "-dataVersion", processSettings.data_version });
+
+    // Depending on the hardware the client sometimes needs a second or two.
+    size_t connectionAttempts = 0;
+    constexpr size_t abondonConnectionAttemptAfter = 60; // sec
+    constexpr bool withDebugOutput = false;
+    while (!m_client.Connect(m_localHost, portClient, withDebugOutput))
+    {
+        ++connectionAttempts;
+        sc2::SleepFor(1000);
+        if (connectionAttempts > abondonConnectionAttemptAfter)
+        {
+            PrintThread{} << "Failed to connect client (" << m_botConfig.BotName << ")" << std::endl;
+            return false;
+        }
+    }
+
+    // Check if client is reacting
+    sc2::ProtoInterface proto;
+    sc2::GameRequestPtr request = proto.MakeRequest();
+    request->mutable_ping();
+    m_client.Send(request.get());
+    auto* response = receiveResponse();
+    return response;
+}
+
+// Technically, we only need opponents race. But I think it looks clearer on the caller side with both races.
+bool Proxy::setupGame(const sc2::ProcessSettings& processSettings, const std::string& map, const bool realTimeMode, const sc2::Race bot1Race, const sc2::Race bot2Race)
+{
+    // Only one client needs to / is allowed to send the create game request.
+    if (m_mapAlreadyLoaded)
+    {
+        return true;
+    }
+    sc2::ProtoInterface proto;
+    sc2::GameRequestPtr request = proto.MakeRequest();
+
+    SC2APIProtocol::RequestCreateGame* requestCreateGame = request->mutable_create_game();
+
+    // Player 1
+    SC2APIProtocol::PlayerSetup* playerSetup = requestCreateGame->add_player_setup();
+    playerSetup->set_type(SC2APIProtocol::PlayerType::Participant);
+    playerSetup->set_race(SC2APIProtocol::Race(static_cast<int>(bot1Race) + 1)); // Ugh
+    playerSetup->set_difficulty(SC2APIProtocol::Difficulty::VeryEasy);
+
+    // Player 2
+    playerSetup = requestCreateGame->add_player_setup();
+    playerSetup->set_type(SC2APIProtocol::PlayerType::Participant);
+    playerSetup->set_race(SC2APIProtocol::Race(static_cast<int>(bot2Race) + 1));
+    playerSetup->set_difficulty(SC2APIProtocol::Difficulty::VeryEasy);
+
+    // Map
+    // BattleNet map
+    if (!sc2::HasExtension(map, ".SC2Map"))
+    {
+        requestCreateGame->set_battlenet_map_name(map);
+    }
+    else
+    {
+        // Local map file
+        SC2APIProtocol::LocalMap* localMap = requestCreateGame->mutable_local_map();
+        // Absolute path
+        if (sc2::DoesFileExist(map))
+        {
+            localMap->set_map_path(map);
+        }
+        else
+        {
+
+            // Relative path - Game maps directory
+            const std::string game_relative = sc2::GetGameMapsDirectory(processSettings.process_path) + map;
+            if (sc2::DoesFileExist(game_relative))
+            {
+                localMap->set_map_path(map);
+            }
+            else
+            {
+                // Relative path - Library maps directory
+                const std::string libraryRelative = sc2::GetLibraryMapsDirectory() + map;
+                if (sc2::DoesFileExist(libraryRelative))
+                {
+                    localMap->set_map_path(libraryRelative);
+                }
+                else
+                {
+                    return false;
+                    // Relative path - Remotely saved maps directory
+                    // toDo
+                    //localMap->set_map_path(map);
+                }
+            }
+        }
+    }
+
+    // Real time mode
+    requestCreateGame->set_realtime(realTimeMode);
+
+    // Send the request
+    m_client.Send(request.get());
+    SC2APIProtocol::Response* createGameResponse = receiveResponse();
+
+    // Check if the request was successful
+    if (!createGameResponse || createGameHasErrors(createGameResponse->create_game()))
+    {
+        return false;
+    }
+    m_mapAlreadyLoaded = true;
+    return true;
+}
+
+bool Proxy::startBot(const int portServer, const int portStart, const std::string & opponentPlayerId)
+{
+    std::string botStartCommand = GetBotCommandLine(portServer, portStart, opponentPlayerId);
+    if (botStartCommand == m_botConfig.executeCommand)
+    {
+        return false;
+    }
+    m_botProgramThread = std::async(std::launch::async, &StartBotProcess, m_botConfig, botStartCommand, &m_botThreadId);
+    if (m_botProgramThread.wait_for(2s) == std::future_status::ready)
+    {
+        return false;
+    }
+    return true;
+}
+
+void Proxy::startGame()
+{
+    m_gameUpdateThread = std::async(std::launch::async, &Proxy::gameUpdate, this);
+}
+
+bool Proxy::gameFinished() const
+{
+    return std::future_status::ready == m_gameUpdateThread.wait_for(0ms);
+}
+
+ExitCase Proxy::getResult() const
+{
+    return m_result;
+}
+
+bool Proxy::createGameHasErrors(const SC2APIProtocol::ResponseCreateGame& createGameResponse) const
+{
+    bool hasError = false;
+    if (createGameResponse.has_error())
+    {
+        std::string errorCode = "Unknown";
+        switch (createGameResponse.error())
+        {
+        case SC2APIProtocol::ResponseCreateGame::MissingMap:
+        {
+            errorCode = "Missing Map";
+            break;
+        }
+        case SC2APIProtocol::ResponseCreateGame::InvalidMapPath:
+        {
+            errorCode = "Invalid Map Path";
+            break;
+        }
+        case SC2APIProtocol::ResponseCreateGame::InvalidMapData:
+        {
+            errorCode = "Invalid Map Data";
+            break;
+        }
+        case SC2APIProtocol::ResponseCreateGame::InvalidMapName:
+        {
+            errorCode = "Invalid Map Name";
+            break;
+        }
+        case SC2APIProtocol::ResponseCreateGame::InvalidMapHandle:
+        {
+            errorCode = "Invalid Map Handle";
+            break;
+        }
+        case SC2APIProtocol::ResponseCreateGame::MissingPlayerSetup:
+        {
+            errorCode = "Missing Player Setup";
+            break;
+        }
+        case SC2APIProtocol::ResponseCreateGame::InvalidPlayerSetup:
+        {
+            errorCode = "Invalid Player Setup";
+            break;
+        }
+        default:
+        {
+            break;
+        }
+        }
+
+        PrintThread{} << m_botConfig.BotName << " : CreateGame request returned an error code: " << errorCode << " (" << createGameResponse.error() << ")" << std::endl;
+        hasError = true;
+    }
+    if (createGameResponse.has_error_details() && createGameResponse.error_details().length() > 0)
+    {
+        PrintThread{} << m_botConfig.BotName << " : CreateGame request returned error details: " << createGameResponse.error_details() << std::endl;
+        hasError = true;
+    }
+    return hasError;
+}
+
+std::string Proxy::GetBotCommandLine(const int gamePort, const int startPort, const std::string &OpponentId, bool CompOpp, sc2::Race CompRace, sc2::Difficulty CompDifficulty) const
+{
+    // Add universal arguments
+    std::string OutCmdLine = m_botConfig.executeCommand + " --GamePort " + std::to_string(gamePort) + " --StartPort " + std::to_string(startPort) + " --LadderServer " + m_localHost + " --OpponentId " + OpponentId;
+
+    if (CompOpp)
+    {
+        OutCmdLine += " --ComputerOpponent 1 --ComputerRace " + GetRaceString(CompRace) + " --ComputerDifficulty " + GetDifficultyString(CompDifficulty);
+    }
+
+    return OutCmdLine;
+}
+
+
+
+void Proxy::gameUpdate()
+{
+    PrintThread{} << "Starting proxy for " << m_botConfig.BotName << std::endl;
+    // toDo: somehow check if the other functions were already used.
+
+
+    // Actually, the game still loads...
+    const auto gameStartTime = std::chrono::system_clock::now();
+    // The bot has 1 minute + time out time to send the first request.
+    bool alreadySurrendered = false;
+    ExitCase currentExitCase = ExitCase::Unknown;
+
+    while (m_gameStatus == SC2APIProtocol::Status::in_game || m_gameStatus == SC2APIProtocol::Status::init_game || m_gameStatus == SC2APIProtocol::Status::launched)
+    {
+        // If we know that the bot crashed we surrender for it.
+        if (currentExitCase == ExitCase::BotCrashed || currentExitCase == ExitCase::BotStepTimeout)
+        {
+            // The bot is dead. So we will surrender on its behalf
+            if(!alreadySurrendered)
+            {
+                terminateGame();
+                alreadySurrendered = true;
+            }
+            // and step the simulation until the match has officially ended.
+            else
+            {
+                doAStep();
+            }
+            continue;
+        }
+
+        if (m_server.HasRequest())
+        {
+            const sc2::RequestData& request = m_server.PeekRequest();
+            // Analyse request
+            // Returns false if a quit request was made.
+            bool validRequest = processRequest(request);
+            // A quit request is handled as if the bot crashed.
+            // Especially, we do not want to forward the request to the client.
+            // We still need it for the replay.
+            if (!validRequest)
+            {
+                currentExitCase = ExitCase::BotCrashed;
+                continue;
+            }
+            // Forward the valid request
+            m_server.SendRequest(m_client.connection_);
+
+            // Block for sc2's response then queue it.
+            SC2APIProtocol::Response* response = receiveResponse();
+            bool validResponse = processResponse(response);
+
+            if (!validResponse)
+            {
+                PrintThread{} << m_botConfig.BotName << " : response not valid." << std::endl;
+                currentExitCase = ExitCase::Error;
+                break;
+            }
+            // Send the response back to the client.
+            if (!m_server.connections_.empty() && m_client.connection_ != nullptr)
+            {
+                m_server.QueueResponse(m_client.connection_, response);
+                m_server.SendResponse();
+            }
+            else
+            {
+                // This usually happens if the bot crashed.
+                // Check if the bot thread has send the crashed signal aka ready signal.
+                if (isBotCrashed(1000))
+                {
+                    PrintThread{} << m_botConfig.BotName << " : crashed." << std::endl;
+                    currentExitCase = ExitCase::BotCrashed;
+                    continue;
+                }
+                // Maybe it is the client ?
+                if (isClientCrashed(1000))
+                {
+                    PrintThread{} << m_botConfig.BotName << " : crashed." << std::endl;
+                }
+                // toDo: Are there other cases when this happens?
+                if (m_server.connections_.empty())
+                {
+                    PrintThread{} << m_botConfig.BotName << " : Response: m_server.connections_.empty()" << std::endl;
+                }
+                else
+                {
+                    PrintThread{} << m_botConfig.BotName << " : Response: m_client.connection_ == nullptr" << std::endl;
+                }
+                currentExitCase = ExitCase::Error;
+                break;
+            }
+        }
+        else
+        {
+            const uint32_t maxStepTime = getMaxStepTime();
+
+            const auto timeSinceLastResponse = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - m_lastResponseSendTime).count();
+            if (!m_botConfig.Debug && maxStepTime && timeSinceLastResponse > static_cast<int>(maxStepTime))
+            {
+                PrintThread{} << m_botConfig.BotName << " : bot is too slow. " << timeSinceLastResponse << " ms passed. Max step time: " << static_cast<int>(maxStepTime) << std::endl;
+                // ToDo: Make a chat announcment
+                // ToDo: Can we handle this better. It
+                currentExitCase = ExitCase::BotStepTimeout;
+            }
+
+            // Check if the bot thread has send the crashed signal.
+            // This is a fast check to not slow down the game
+            if (isBotCrashed(0))
+            {
+                PrintThread{} << m_botConfig.BotName << " : crashed." << std::endl;
+                currentExitCase = ExitCase::BotCrashed;
+                continue;
+            }
+            if (m_server.connections_.empty() || m_client.connection_ == nullptr)
+            {
+                // Time for a serious check if the bot crashed.
+                if (isBotCrashed(1000))
+                {
+                    PrintThread{} << m_botConfig.BotName << " : crashed." << std::endl;
+                    currentExitCase = ExitCase::BotCrashed;
+                    continue;
+                }
+                // Maybe it is the client ?
+                if (isClientCrashed(1000))
+                {
+                    PrintThread{} << m_botConfig.BotName << " : crashed." << std::endl;
+                }
+                if (m_server.connections_.empty())
+                {
+                    PrintThread{} << m_botConfig.BotName << " : Receive: server->connections_.empty()" << std::endl;
+                    currentExitCase = ExitCase::Error;
+                    break;
+                }
+
+                // If there is no connection to the client it probably crashed.
+                if (m_client.connection_ == nullptr)
+                {
+                    PrintThread{} << m_botConfig.BotName << " :  Receive: m_client.connection_ == nullptr" << std::endl;
+                    currentExitCase = ExitCase::Error;
+                    break;
+                }
+            }
+        }
+        const auto gameDurationRealTime = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - gameStartTime).count();
+        if (m_maxRealGameTime && gameDurationRealTime > m_maxRealGameTime)
+        {
+            m_result = ExitCase::GameTimeOver;
+        }
+    }
+
+    if (currentExitCase == ExitCase::Unknown)
+    {
+        // The game ended normally for this bot. Get the result from the observation.
+        const SC2APIProtocol::Result result = getGameResult();
+        switch (result)
+        {
+        case SC2APIProtocol::Result::Victory:
+        {
+            currentExitCase = ExitCase::GameEndVictory;
+            break;
+        }
+        case SC2APIProtocol::Result::Defeat:
+        {
+            currentExitCase = ExitCase::GameEndDefeat;
+            break;
+        }
+        case SC2APIProtocol::Result::Tie:
+        {
+            currentExitCase = ExitCase::GameEndTie;
+            break;
+        }
+        case SC2APIProtocol::Result::Undecided:
+        default:
+        {
+            currentExitCase = ExitCase::Error;
+            break;
+        }
+        }
+    }
+    m_stats.avgLoopDuration = m_totalTime/static_cast<float>(m_currentGameLoop)/1000.0f;
+    m_stats.gameLoops = m_currentGameLoop;
+    m_result = currentExitCase;
+    PrintThread{} << m_botConfig.BotName << " : Exiting with " << GetExitCaseString(currentExitCase) << " Average step time " << m_stats.avgLoopDuration << " microseconds, total time: " << m_totalTime/1000000.0f << " seconds, game loops: " << m_currentGameLoop << std::endl;
+}
+
+bool Proxy::isBotCrashed(const int millisecons) const
+{
+    return m_botProgramThread.wait_for(std::chrono::milliseconds(millisecons)) == std::future_status::ready;
+}
+
+bool Proxy::isClientCrashed(const int) const
+{
+    // toDo
+    // Big effort due to cross compatibility,
+    // little gain since it is only needed to make a clearer error message.
+    return false;
+}
+
+bool Proxy::processRequest(const sc2::RequestData& request)
+{
+    if (request.second)
+    {
+        if (request.second->has_quit())
+        {
+            // Intercept quit requests, we want to keep game alive to save replays.
+            // If a s2client-api (c++) throws an exception a quit request gets issued.
+            // So check if it crashed.
+            if (isBotCrashed(1000))
+            {
+                PrintThread{} << m_botConfig.BotName << " : crashed." << std::endl;
+            }
+            else
+            {
+                PrintThread{} << m_botConfig.BotName << " HAS ISSUED A QUIT REQUEST. Please tell the author not to." << std::endl;
+            }
+            return false;
+        }
+        else if (request.second->has_leave_game())
+        {
+            // Leave game requests are also a problem.
+            // ToDo: Read a "gg" from chat
+            PrintThread{} << m_botConfig.BotName << " has issued a leave game request. Please don't do that." << std::endl;
+            return false;
+        }
+        else if (request.second->has_debug() && !m_usedDebugInterface)
+        {
+            PrintThread{} << m_botConfig.BotName << " : IS USING DEBUG INTERFACE.  POSSIBLE CHEAT! Please tell them not to." << std::endl;
+            m_usedDebugInterface = true;
+        }
+        else if (request.second->has_step() && m_currentGameLoop)
+        {
+            const auto thisStepTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - m_lastResponseSendTime).count();
+            m_totalTime += static_cast<float_t>(thisStepTime);
+        }
+    }
+    return true;
+}
+
+bool Proxy::processResponse(const SC2APIProtocol::Response* response)
+{
+    if (response == nullptr)
+    {
+        PrintThread{} << m_botConfig.BotName << " : Waiting for a response had a timeout." << std::endl;
+        return false;
+    }
+    if (response->has_observation())
+    {
+        const SC2APIProtocol::Observation& observation = response->observation().observation();
+        m_currentGameLoop = observation.game_loop();
+        // toDo: handle forced tie situation
+        //if (ExitCase::TimeOut)
+        //{
+            //auto test = m_response.mutable_observation();
+            //auto test2 = test->add_player_result();
+            //test2->set_result(SC2APIProtocol::Result::Tie);
+        //}
+
+        if (m_maxGameLoops && m_currentGameLoop > m_maxGameLoops)
+        {
+            terminateGame();
+            m_result = ExitCase::GameTimeOver;
+        }
+    }
+    if (response->has_step())
+    {
+        m_lastResponseSendTime = std::chrono::system_clock::now();
+    }
+    return true;
+}
+
+
+void Proxy::terminateGame()
+{
+    sc2::ProtoInterface proto;
+    sc2::GameRequestPtr request = proto.MakeRequest();
+
+    SC2APIProtocol::RequestDebug* debugRequest = request->mutable_debug();
+
+    auto debugCommand = debugRequest->add_debug();
+    auto endGame = debugCommand->mutable_end_game();
+    // If the proxy has to end the game it is because the bot failed somehow (crash, too slow, etc), aka lost.
+    endGame->set_end_result(SC2APIProtocol::DebugEndGame_EndResult::DebugEndGame_EndResult_Surrender);
+
+    m_client.Send(request.get());
+    SC2APIProtocol::Response* debugResponse = receiveResponse();
+    if (debugResponse)
+    {
+        // toDo check for errors and whether it is actually a debug response
+        PrintThread{} << m_botConfig.BotName << " : surrender" << std::endl;
+        if (debugResponse->has_status())
+        {
+            updateStatus(debugResponse->status());
+        }
+    }
+}
+
+// If the bot is dead and the opponent bot has a step_size so that
+// the current loop is an 'off step' loop the proxy needs to step on behalf of the bot.
+void Proxy::doAStep()
+{
+    sc2::ProtoInterface proto;
+    sc2::GameRequestPtr request = proto.MakeRequest();
+
+    SC2APIProtocol::RequestStep* stepRequest = request->mutable_step();
+
+    stepRequest->set_count(1); // ToDo: this can be made smarter
+    m_client.Send(request.get());
+    SC2APIProtocol::Response* response = receiveResponse();
+    if (response)
+    {
+        // todo: correct response?
+        PrintThread{} << m_botConfig.BotName << " : step"<< std::endl;
+        if (response->has_status())
+        {
+            updateStatus(response->status());
+        }
+    }
+}
+
+uint32_t Proxy::getMaxStepTime() const
+{
+    if (m_currentGameLoop)
+    {
+        return 50U;  // ToDo: Add this to config file.
+    }
+    return 0U;
+}
+
+void Proxy::updateStatus(const SC2APIProtocol::Status newStatus)
+{
+    if (newStatus != m_gameStatus)
+    {
+        PrintThread{} << m_botConfig.BotName << " : Client changed status from "<< statusToString(m_gameStatus) << " to " << statusToString(newStatus) << std::endl;
+        m_gameStatus = newStatus;
+    }
+}
+
+bool Proxy::saveReplay(const std::string& replayFile)
+{
+    if (m_result == ExitCase::Error)
+    {
+        PrintThread{} << m_botConfig.BotName << " : Match ended in error. Can not save replay." << std::endl;
+        // Maybe we could. But most likely we will get an assertion failed or even exception. Better safe than sorry.
+        return false;
+    }
+    PrintThread{} << m_botConfig.BotName << " : Saving replay." << std::endl;
+    sc2::ProtoInterface proto;
+    sc2::GameRequestPtr request = proto.MakeRequest();
+    request->mutable_save_replay();
+    m_client.Send(request.get());
+    SC2APIProtocol::Response* response = receiveResponse();
+    if (!response || !response->has_save_replay())
+    {
+        PrintThread{} << m_botConfig.BotName << " : Failed to receive replay response." << std::endl;
+        return false;
+    }
+
+    const SC2APIProtocol::ResponseSaveReplay& replay = response->save_replay();
+
+    if (replay.data().empty())
+    {
+        PrintThread{} << m_botConfig.BotName << " : Replay data empty." << std::endl;
+        return false;
+    }
+
+    std::ofstream file;
+    file.open(replayFile, std::fstream::binary);
+    if (!file.is_open())
+    {
+        PrintThread{} << m_botConfig.BotName << " : Could not open replay file." << std::endl;
+        return false;
+    }
+
+    file.write(&replay.data()[0], static_cast<std::streamsize>(replay.data().size()));
+    return true;
+}
+
+// toDo: change all receives
+// toDo: give the expected response type
+SC2APIProtocol::Response* Proxy::receiveResponse()
+{
+    SC2APIProtocol::Response* response{nullptr};
+    if (!m_client.Receive(response, m_responseTimeOutMS))
+    {
+        return nullptr;
+    }
+    if (response->error_size())
+    {
+        std::ostringstream ss;
+        ss << m_botConfig.BotName << " : response '" << responseCaseToString(response->response_case()) << "' has " << response->error_size() << "  error(s)!" << std::endl;
+        for (int i(0); i < response->error_size(); ++i)
+        {
+            ss << "\t * " << response->error(i) << std::endl;
+        }
+        return nullptr;
+    }
+    // During the game we only update the status if the bot also gets the update at the same time.
+    // The bot gets the update via the observation, so we can only update if the response has an observation.
+    // If we wouldn't do this, the LM would know the game ended and wouldn't proxy anymore steps.
+    // Bad if the bot has an 'off step' due to step size != 1.
+    if (response->has_status() && (response->has_observation() || m_gameStatus != SC2APIProtocol::Status::in_game))
+    {
+        updateStatus(response->status());
+    }
+    return response;
+}
+
+const Stats& Proxy::stats() const
+{
+    return m_stats;
+}
+
+SC2APIProtocol::Result Proxy::getGameResult()
+{
+
+    sc2::ProtoInterface proto;
+    sc2::GameRequestPtr request = proto.MakeRequest();
+
+    request->mutable_observation();
+    m_client.Send(request.get());
+    SC2APIProtocol::Response* observationResponse = receiveResponse();
+    if (observationResponse)
+    {
+        const SC2APIProtocol::ResponseObservation& obs = observationResponse->observation();
+        const SC2APIProtocol::Observation& observation = obs.observation();
+        const auto playerID = observation.player_common().player_id();
+        for (int i(0); i < obs.player_result_size(); ++i)
+        {
+            if (obs.player_result(i).player_id() == playerID)
+            {
+                return obs.player_result(i).result();
+            }
+        }
+    }
+    return SC2APIProtocol::Result::Undecided;
+}

--- a/src/sc2laddercore/Proxy.h
+++ b/src/sc2laddercore/Proxy.h
@@ -2,12 +2,13 @@
 
 #include "AgentsConfig.h"
 
+#include <string>
+#include <future>
+
 #include "sc2api/sc2_game_settings.h"
 #include "sc2api/sc2_connection.h"
 #include "sc2api/sc2_server.h"
 
-#include <string>
-#include <future>
 
 struct Stats
 {
@@ -20,18 +21,6 @@ struct Stats
 
 class Proxy
 {
-    // Proxy
-    enum class Status
-    {
-        Unknown,
-        Init,
-        SC2ClientStarted,
-        MapLoaded,
-        BotStated,
-        GameInProgress,
-        GameFinished
-    };
-
     // Client
     sc2::Server m_server{};
     sc2::Connection m_client{};
@@ -40,7 +29,7 @@ class Proxy
     // Game
     static bool m_mapAlreadyLoaded;
     const uint32_t m_maxGameLoops{0U};
-    const uint32_t m_maxRealGameTime{0U}; //sec
+    const uint32_t m_maxRealGameTime{0U};  // sec
     uint32_t m_currentGameLoop{0U};
     SC2APIProtocol::Status m_gameStatus{SC2APIProtocol::Status::unknown};
     std::future<void> m_gameUpdateThread{};
@@ -54,37 +43,34 @@ class Proxy
 
     // stats
     Stats m_stats;
-    std::chrono::time_point<std::chrono::system_clock> m_lastResponseSendTime{};
-    float_t m_totalTime{0.0f};
+    using clock = std::chrono::system_clock;  // there is also steady_clock and high_resolution_clock
+    clock::time_point m_lastResponseSendTime{};
+    clock::duration m_totalTime{std::chrono::seconds(0)};
 
 
     // constants
-    static constexpr auto m_localHost{"127.0.0.1"}; // is there a way to get this without hardcoding
+    static constexpr auto m_localHost{"127.0.0.1"};  // is there a way to get this without hardcoding?
     static constexpr int m_responseTimeOutMS{100000};
 
 
     bool createGameHasErrors(const SC2APIProtocol::ResponseCreateGame& createGameResponse) const;
-    void stepGame();
-    void endGame();
     std::string GetBotCommandLine(const int gamePort, const int startPort, const std::string &OpponentId, const bool CompOpp = false, const sc2::Race CompRace = sc2::Race::Random, sc2::Difficulty CompDifficulty = sc2::Difficulty::VeryEasy) const;
     bool isBotCrashed(const int ms) const;
     bool isClientCrashed(const int ms) const;
     bool processRequest(const sc2::RequestData& request);
-    bool processResponse(const SC2APIProtocol::Response* response);
-    void processObservation();
+    bool processResponse(SC2APIProtocol::Response* const response);
     void gameUpdate();
     void terminateGame();
     void doAStep();
     void updateStatus(const SC2APIProtocol::Status newStatus);
     uint32_t getMaxStepTime() const;
-    SC2APIProtocol::Response* receiveResponse();
+    SC2APIProtocol::Response* receiveResponse(SC2APIProtocol::Response::ResponseCase responseCase);
     SC2APIProtocol::Result getGameResult();
 
-public:
-
-    Proxy()=delete;
+ public:
+    Proxy() = delete;
     ~Proxy();
-    Proxy(const uint32_t maxGameLoops,const uint32_t maxRealGameTime, const BotConfig& botConfig);
+    Proxy(const uint32_t maxGameLoops, const uint32_t maxRealGameTime, const BotConfig& botConfig);
 
     bool startSC2Instance(const sc2::ProcessSettings& processSettings, const int portServer, const int portClient);
     bool setupGame(const sc2::ProcessSettings& processSettings, const std::string& map, const bool realTimeMode, const sc2::Race bot1Race, const sc2::Race bot2Race);
@@ -95,5 +81,4 @@ public:
     bool saveReplay(const std::string& replayFile);
     ExitCase getResult() const;
     const Stats& stats() const;
-
 };

--- a/src/sc2laddercore/Proxy.h
+++ b/src/sc2laddercore/Proxy.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "AgentsConfig.h"
+
+#include "sc2api/sc2_game_settings.h"
+#include "sc2api/sc2_connection.h"
+#include "sc2api/sc2_server.h"
+
+#include <string>
+#include <future>
+
+struct Stats
+{
+    float avgLoopDuration{0.0f};
+    size_t gameLoops{0U};
+    // Fill this with more stats
+    // time for first Loop
+    // number of actions
+};
+
+class Proxy
+{
+    // Proxy
+    enum class Status
+    {
+        Unknown,
+        Init,
+        SC2ClientStarted,
+        MapLoaded,
+        BotStated,
+        GameInProgress,
+        GameFinished
+    };
+
+    // Client
+    sc2::Server m_server{};
+    sc2::Connection m_client{};
+    uint64_t m_gameClientPid{0UL};
+
+    // Game
+    static bool m_mapAlreadyLoaded;
+    const uint32_t m_maxGameLoops{0U};
+    const uint32_t m_maxRealGameTime{0U}; //sec
+    uint32_t m_currentGameLoop{0U};
+    SC2APIProtocol::Status m_gameStatus{SC2APIProtocol::Status::unknown};
+    std::future<void> m_gameUpdateThread{};
+    ExitCase m_result{ExitCase::Unknown};
+
+    // Bot
+    const BotConfig m_botConfig{};
+    std::future<void> m_botProgramThread{};
+    unsigned long m_botThreadId{0};
+    bool m_usedDebugInterface{false};
+
+    // stats
+    Stats m_stats;
+    std::chrono::time_point<std::chrono::system_clock> m_lastResponseSendTime{};
+    float_t m_totalTime{0.0f};
+
+
+    // constants
+    static constexpr auto m_localHost{"127.0.0.1"}; // is there a way to get this without hardcoding
+    static constexpr int m_responseTimeOutMS{100000};
+
+
+    bool createGameHasErrors(const SC2APIProtocol::ResponseCreateGame& createGameResponse) const;
+    void stepGame();
+    void endGame();
+    std::string GetBotCommandLine(const int gamePort, const int startPort, const std::string &OpponentId, const bool CompOpp = false, const sc2::Race CompRace = sc2::Race::Random, sc2::Difficulty CompDifficulty = sc2::Difficulty::VeryEasy) const;
+    bool isBotCrashed(const int ms) const;
+    bool isClientCrashed(const int ms) const;
+    bool processRequest(const sc2::RequestData& request);
+    bool processResponse(const SC2APIProtocol::Response* response);
+    void processObservation();
+    void gameUpdate();
+    void terminateGame();
+    void doAStep();
+    void updateStatus(const SC2APIProtocol::Status newStatus);
+    uint32_t getMaxStepTime() const;
+    SC2APIProtocol::Response* receiveResponse();
+    SC2APIProtocol::Result getGameResult();
+
+public:
+
+    Proxy()=delete;
+    ~Proxy();
+    Proxy(const uint32_t maxGameLoops,const uint32_t maxRealGameTime, const BotConfig& botConfig);
+
+    bool startSC2Instance(const sc2::ProcessSettings& processSettings, const int portServer, const int portClient);
+    bool setupGame(const sc2::ProcessSettings& processSettings, const std::string& map, const bool realTimeMode, const sc2::Race bot1Race, const sc2::Race bot2Race);
+    bool startBot(const int portServer, const int portStart, const std::string & opponentPlayerId);
+    void startGame();
+
+    bool gameFinished() const;
+    bool saveReplay(const std::string& replayFile);
+    ExitCase getResult() const;
+    const Stats& stats() const;
+
+};

--- a/src/sc2laddercore/ToolsUnix.cpp
+++ b/src/sc2laddercore/ToolsUnix.cpp
@@ -148,6 +148,11 @@ void SleepFor(int seconds)
 
 void KillBotProcess(unsigned long pid)
 {
+    if (pid == 0)
+    {
+        //Maybe a warning?
+        return;
+    }
     int ret = kill(pid, SIGKILL);
     if (ret < 0)
     {

--- a/src/sc2laddercore/ToolsWindows.cpp
+++ b/src/sc2laddercore/ToolsWindows.cpp
@@ -68,7 +68,7 @@ void StartBotProcess(const BotConfig &Agent, const std::string &CommandLine, uns
 		size_t size = FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
 			NULL, dw, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&lpMsgBuf, 0, NULL);
 		std::string message(lpMsgBuf, size);
-		PrintThread{} << "Starting bot: " << Agent.BotName << " with command:" << std::endl << CommandLine << std::endl << "...failed" << std::endl << "Error " << dw << " : " << message << std::endl;
+		PrintThread{} << "Starting bot: " << Agent.BotName << " with command:" << std::endl << CommandLine << " failed. Error " << dw << " : " << message << std::endl;
 		// Free resources created by the system
 		LocalFree(lpMsgBuf);
 		// We failed.
@@ -76,7 +76,7 @@ void StartBotProcess(const BotConfig &Agent, const std::string &CommandLine, uns
 	}
 	else
 	{
-		PrintThread{} << "Starting bot: " << Agent.BotName << " with command:" << std::endl << CommandLine << std::endl << "...success!" << std::endl;
+		PrintThread{} << "Starting bot: " << Agent.BotName << " with command:" << CommandLine << std::endl;
 		// Successfully created the process.  Wait for it to finish.
 		*ProcessId = processInformation.dwProcessId;
 		WaitForSingleObject(processInformation.hProcess, INFINITE);

--- a/src/sc2laddercore/Types.h
+++ b/src/sc2laddercore/Types.h
@@ -37,15 +37,17 @@ enum BotType
     NodeJS,
 };
 
-enum ResultType
+enum class ResultType
 {
 	InitializationError,
 	Timeout,
 	ProcessingReplay,
-	Player1Win,
-	Player1Crash,
+    Player1Win,
+    Player1Crash,
+    Player1TimeOut,
 	Player2Win,
 	Player2Crash,
+    Player2TimeOut,
 	Tie,
 	Error
 };
@@ -57,15 +59,16 @@ enum MatchupListType
     None
 };
 
-enum ExitCase
+enum class ExitCase
 {
-	InProgress,
-	GameEnd,
-    ClientError,
-    ServerError,
-    BotTimeout,
+    Unknown,
+    GameEndVictory,
+    GameEndDefeat,
+    GameEndTie,
+    BotStepTimeout,
     BotCrashed,
-    GameTimeout
+    GameTimeOver,
+    Error
 };
 
 struct GameState
@@ -112,6 +115,8 @@ struct BotConfig
     bool Enabled;
     bool Skeleton;
     int ELO;
+    std::string executeCommand;
+
 	BotConfig()
 		: Type(BotType::BinaryCpp)
 		, Race(sc2::Race::Random)
@@ -121,21 +126,23 @@ struct BotConfig
         , Skeleton(false)
         , ELO(0)
 	{}
+
 	BotConfig(BotType InType, const std::string & InBotName, sc2::Race InBotRace, const std::string & InBotPath, const std::string & InFileName, sc2::Difficulty InDifficulty = sc2::Difficulty::Easy, const std::string & InArgs = "")
-		: Type(InType)
-		, Race(InBotRace)
+        : Type(InType)
 		, BotName(InBotName)
 		, RootPath(InBotPath)
-		, FileName(InFileName)
+        , FileName(InFileName)
+        , Race(InBotRace)
 		, Difficulty(InDifficulty)
 		, Args(InArgs)
 		, Debug(false)
         , Skeleton(false)
     {}
+
 	bool operator ==(const BotConfig &Other) const
 	{
 		return BotName == Other.BotName;
-	}
+    }
 };
 
 struct Matchup
@@ -181,21 +188,23 @@ static MatchupListType GetMatchupListTypeFromString(const std::string GeneratorT
 static std::string GetExitCaseString(ExitCase ExitCaseIn)
 {
 	switch (ExitCaseIn)
-	{
+    {
     case ExitCase::BotCrashed:
         return "BotCrashed";
-    case ExitCase::BotTimeout:
-        return "BotTimeout";
-    case ExitCase::ClientError:
-        return "ClientError";
-	case ExitCase::GameEnd:
-		return "GameEnd";
-	case ExitCase::GameTimeout:
-        return "GameTimeout";
-    case ExitCase::InProgress:
-        return "InProgress";
-    case ExitCase::ServerError:
-        return "ServerError";
+    case ExitCase::BotStepTimeout:
+        return "BotStepTimeout";
+    case ExitCase::Error:
+        return "Error";
+    case ExitCase::GameEndVictory:
+        return "GameEndWin";
+    case ExitCase::GameEndDefeat:
+        return "GameEndLoss";
+    case ExitCase::GameEndTie:
+        return "GameEndTie";
+    case ExitCase::GameTimeOver:
+        return "GameTimeOver";
+    case ExitCase::Unknown:
+        return "Unknown";
 	}
 	return "Error";
 }
@@ -383,28 +392,34 @@ static std::string GetResultType(ResultType InResultType)
 {
 	switch (InResultType)
 	{
-	case InitializationError:
+    case ResultType::InitializationError:
 		return "InitializationError";
 
-	case Timeout:
+    case ResultType::Timeout:
 		return "Timeout";
 
-	case ProcessingReplay:
+    case ResultType::ProcessingReplay:
 		return "ProcessingReplay";
 
-	case Player1Win:
+    case ResultType::Player1Win:
 		return "Player1Win";
 
-	case Player1Crash:
-		return "Player1Crash";
+    case ResultType::Player1Crash:
+        return "Player1Crash";
 
-	case Player2Win:
+    case ResultType::Player1TimeOut:
+        return "Player1TimeOut";
+
+    case ResultType::Player2Win:
 		return "Player2Win";
 
-	case Player2Crash:
+    case ResultType::Player2Crash:
 		return "Player2Crash";
 
-	case Tie:
+    case ResultType::Player2TimeOut:
+        return "Player2TimeOut";
+
+    case ResultType::Tie:
 		return "Tie";
 
 	default:
@@ -420,4 +435,87 @@ static std::string RemoveMapExtension(const std::string& filename)
         return filename;
     }
     return filename.substr(0, lastdot);
+}
+
+static ResultType getEndResultFromProxyResults(const ExitCase resultBot1, const ExitCase resultBot2)
+{
+    if ((resultBot1 == ExitCase::BotCrashed && resultBot2 == ExitCase::BotCrashed)
+            || (resultBot1 == ExitCase::BotStepTimeout && resultBot2 == ExitCase::BotStepTimeout)
+            || resultBot1 == ExitCase::Error
+            || resultBot2 == ExitCase::Error)
+    {
+        // If both bots crashed we assume the bots are not the problem.
+        return ResultType::Error;
+    }
+    if (resultBot1 == ExitCase::BotCrashed)
+    {
+        return ResultType::Player1Crash;
+    }
+    if (resultBot2 == ExitCase::BotCrashed)
+    {
+        return ResultType::Player2Crash;
+    }
+    if (resultBot1 == ExitCase::GameEndVictory && (resultBot2 == ExitCase::GameEndDefeat || resultBot2 == ExitCase::BotStepTimeout))
+    {
+        return  ResultType::Player1Win;
+    }
+    if (resultBot2 == ExitCase::GameEndVictory && (resultBot1 == ExitCase::GameEndDefeat || resultBot1 == ExitCase::BotStepTimeout))
+    {
+        return  ResultType::Player2Win;
+    }
+    if (resultBot1 == ExitCase::GameEndTie && resultBot2 == ExitCase::GameEndTie)
+    {
+        return  ResultType::Tie;
+    }
+    if (resultBot1 == ExitCase::GameTimeOver && resultBot2 == ExitCase::GameTimeOver)
+    {
+        return  ResultType::Timeout;
+    }
+    return ResultType::Error;
+}
+
+static std::string statusToString(SC2APIProtocol::Status status)
+{
+    switch (status)
+    {
+    case SC2APIProtocol::Status::launched: return "launched";
+    case SC2APIProtocol::Status::init_game: return "init_game";
+    case SC2APIProtocol::Status::in_game: return "in_game";
+    case SC2APIProtocol::Status::in_replay: return "in_replay";
+    case SC2APIProtocol::Status::ended: return "ended";
+    case SC2APIProtocol::Status::quit: return "quit";
+    case SC2APIProtocol::Status::unknown: return "unknown";
+    }
+    return "unknown (" + std::to_string(static_cast<int>(status)) + ")";
+}
+
+static std::string responseCaseToString(SC2APIProtocol::Response::ResponseCase responseCase)
+{
+    switch(responseCase)
+    {
+    case SC2APIProtocol::Response::ResponseCase::kCreateGame: return "CreateGame";
+    case SC2APIProtocol::Response::ResponseCase::kJoinGame: return "JoinGame";
+    case SC2APIProtocol::Response::ResponseCase::kRestartGame : return "RestartGame";
+    case SC2APIProtocol::Response::ResponseCase::kStartReplay: return "StartReplay";
+    case SC2APIProtocol::Response::ResponseCase::kLeaveGame: return "LeaveGame";
+    case SC2APIProtocol::Response::ResponseCase::kQuickSave: return "QuickSave";
+    case SC2APIProtocol::Response::ResponseCase::kQuickLoad: return "QuickLoad";
+    case SC2APIProtocol::Response::ResponseCase::kQuit: return "Quit";
+    case SC2APIProtocol::Response::ResponseCase::kGameInfo: return "GameInfo";
+    case SC2APIProtocol::Response::ResponseCase::kObservation: return "Observation";
+    case SC2APIProtocol::Response::ResponseCase::kAction: return "Action";
+    case SC2APIProtocol::Response::ResponseCase::kObsAction: return "ObsAction";
+    case SC2APIProtocol::Response::ResponseCase::kStep: return "Step";
+    case SC2APIProtocol::Response::ResponseCase::kData: return "Data";
+    case SC2APIProtocol::Response::ResponseCase::kQuery: return "Query";
+    case SC2APIProtocol::Response::ResponseCase::kSaveReplay: return "SaveReplay";
+    case SC2APIProtocol::Response::ResponseCase::kReplayInfo: return "ReplayInfo";
+    case SC2APIProtocol::Response::ResponseCase::kAvailableMaps: return "AvailableMaps";
+    case SC2APIProtocol::Response::ResponseCase::kSaveMap: return "SaveMap";
+    case SC2APIProtocol::Response::ResponseCase::kMapCommand: return "MapCommand";
+    case SC2APIProtocol::Response::ResponseCase::kPing: return "Ping";
+    case SC2APIProtocol::Response::ResponseCase::kDebug: return "Debug";
+    case SC2APIProtocol::Response::ResponseCase::RESPONSE_NOT_SET: return "RESPONSE_NOT_SET";
+    }
+    return "unknown (" + std::to_string(static_cast<int>(responseCase)) + ")";
 }

--- a/src/sc2laddercore/Types.h
+++ b/src/sc2laddercore/Types.h
@@ -61,9 +61,11 @@ enum ExitCase
 {
 	InProgress,
 	GameEnd,
-	ClientRequestExit,
-	ClientTimeout,
-	GameTimeout
+    ClientError,
+    ServerError,
+    BotTimeout,
+    BotCrashed,
+    GameTimeout
 };
 
 struct GameState
@@ -180,16 +182,20 @@ static std::string GetExitCaseString(ExitCase ExitCaseIn)
 {
 	switch (ExitCaseIn)
 	{
-	case ExitCase::ClientRequestExit:
-		return "ClientRequestExit";
-	case ExitCase::ClientTimeout:
-		return "ClientTimeout";
+    case ExitCase::BotCrashed:
+        return "BotCrashed";
+    case ExitCase::BotTimeout:
+        return "BotTimeout";
+    case ExitCase::ClientError:
+        return "ClientError";
 	case ExitCase::GameEnd:
 		return "GameEnd";
 	case ExitCase::GameTimeout:
-		return "GameTimeout";
-	case ExitCase::InProgress:
-		return "InProgress";
+        return "GameTimeout";
+    case ExitCase::InProgress:
+        return "InProgress";
+    case ExitCase::ServerError:
+        return "ServerError";
 	}
 	return "Error";
 }

--- a/src/sc2laddercore/Types.h
+++ b/src/sc2laddercore/Types.h
@@ -32,7 +32,6 @@ enum BotType
 	Wine,
 	Mono,
 	DotNetCore,
-	DefaultBot,
     Java,
     NodeJS,
 };
@@ -264,10 +263,6 @@ static BotType GetTypeFromString(const std::string &TypeIn)
 	{
 		return BotType::CommandCenter;
 	}
-	else if (type == "computer")
-	{
-		return BotType::DefaultBot;
-	}
 	else if (type == "python")
 	{
 		return BotType::Python;
@@ -441,8 +436,7 @@ static ResultType getEndResultFromProxyResults(const ExitCase resultBot1, const 
 {
     if ((resultBot1 == ExitCase::BotCrashed && resultBot2 == ExitCase::BotCrashed)
             || (resultBot1 == ExitCase::BotStepTimeout && resultBot2 == ExitCase::BotStepTimeout)
-            || resultBot1 == ExitCase::Error
-            || resultBot2 == ExitCase::Error)
+            || (resultBot1 == ExitCase::Error && resultBot2 == ExitCase::Error))
     {
         // If both bots crashed we assume the bots are not the problem.
         return ResultType::Error;
@@ -455,11 +449,11 @@ static ResultType getEndResultFromProxyResults(const ExitCase resultBot1, const 
     {
         return ResultType::Player2Crash;
     }
-    if (resultBot1 == ExitCase::GameEndVictory && (resultBot2 == ExitCase::GameEndDefeat || resultBot2 == ExitCase::BotStepTimeout))
+    if (resultBot1 == ExitCase::GameEndVictory && (resultBot2 == ExitCase::GameEndDefeat || resultBot2 == ExitCase::BotStepTimeout || resultBot2 == ExitCase::Error))
     {
         return  ResultType::Player1Win;
     }
-    if (resultBot2 == ExitCase::GameEndVictory && (resultBot1 == ExitCase::GameEndDefeat || resultBot1 == ExitCase::BotStepTimeout))
+    if (resultBot2 == ExitCase::GameEndVictory && (resultBot1 == ExitCase::GameEndDefeat || resultBot1 == ExitCase::BotStepTimeout || resultBot1 == ExitCase::Error))
     {
         return  ResultType::Player2Win;
     }
@@ -512,7 +506,7 @@ static std::string responseCaseToString(SC2APIProtocol::Response::ResponseCase r
     case SC2APIProtocol::Response::ResponseCase::kReplayInfo: return "ReplayInfo";
     case SC2APIProtocol::Response::ResponseCase::kAvailableMaps: return "AvailableMaps";
     case SC2APIProtocol::Response::ResponseCase::kSaveMap: return "SaveMap";
-    case SC2APIProtocol::Response::ResponseCase::kMapCommand: return "MapCommand";
+    //case SC2APIProtocol::Response::ResponseCase::kMapCommand: return "MapCommand";
     case SC2APIProtocol::Response::ResponseCase::kPing: return "Ping";
     case SC2APIProtocol::Response::ResponseCase::kDebug: return "Debug";
     case SC2APIProtocol::Response::ResponseCase::RESPONSE_NOT_SET: return "RESPONSE_NOT_SET";


### PR DESCRIPTION
I recently noticed that if a bot crashes during a match, the other bot freezes and will also get a kill signal. The LM gets the correct result but due to the kill, the other bot will never know it won.

Since we get an increasing amount of bots that want to learn from past games, this becomes an issue. It even could be abused by "accidentally" trowing an assertion whenever the bot is losing. The opponent would never see a winning strategy because it would be killed whenever it wins.

The purpose of this PR is to fix this issue. Whenever a bot has a problem and has to quit, the opponent should get an observation containing the result that it won.

Since both the `LadderGame::StartGame` and the `GameUpdate` function slowly evolved into 100++ line monsters I did a major refactor of LadderGame.cpp and introduced the new class `Proxy`.

To test the new approach I made several very small python-sc2 example bots to test several scenarios. I categorized the scenarios in three categories, whether they improved the result, the results stayed equal, or if the result became worse.

In the good category we see several cases of the above described theme of one bot crashing and the other one should realize it won. An interesting corner case is when the bot starts a local game. With the current Dev LM it gets declared winner while the other bot supposedly crashed. It also seems that a change in the past broke the maximum game loop support.

I realize this is a lot of changes in the core part of the LM. "It runs on my machine" but I also have not tested it for 200 games per day. Maybe we can think about a setup, where we can run this a few days in parallel @Cryptyc 

Sorry for some of the indention changes that happened during the merge of the new changes on Dev into this.


## Better
### Bot2 sends quit request at game loop 100

#### Expected behavior
Ladder manager: Winner: Bot1, Result: Player2Crash
Bot1: Victory
Bot2: Defeat

#### Used bots
Python_ref vs Python_quit

#### Actual result before this PR
Ladder manager: Winner: Bot1, Result: Player1Win
Bot1: no result (needed kill)
Bot2: no result

#### Actual result after this PR
Ladder manager: Winner: Bot1, Result: Player2Crash
Bot1: Victory
Bot2: no result (needed kill)

### Bot2 has a crash during loop 100

#### Expected behavior
Ladder manager: Winner: Bot1, Result: Player2Crash
Bot1: Victory
Bot2: undefined

#### Used bots
Python_ref vs Python_crash_100

#### Actual result before this PR
Ladder manager: Winner: Bot1, Result: Player2Crash
Bot1: no result (needed kill)
Bot2: no result

#### Actual result after this PR
Ladder manager: Winner: Bot1, Result: Player2Crash
Bot1: Victory
Bot2: no result

### Bot2 throws an assertion during loop 100

#### Expected behavior
Ladder manager: Winner: Bot1, Result: Player2Crash
Bot1: Victory
Bot2: undefined

#### Used bots
Python_ref vs Python_assert_100

#### Actual result before this PR
Ladder manager: Winner: Bot1, Result: Player2Crash
Bot1: no result (needed kill)
Bot2: Defeat (<- Python-sc2 specific)

#### Actual result after this PR
Ladder manager: Winner: Bot1, Result: Player2Crash
Bot1: Victory
Bot2: Defeat (<- Python-sc2 specific)


### Bot2 starts a local game

#### Expected behavior
Ladder manager: Winner: Error, Result: InitializationError
Bot1: no result
Bot2: undefined

#### Used bots
Python_ref vs Python_hijack

#### Actual result before this PR
Ladder manager: Winner: Python_hijack, Result: Player1Crash !!
Bot1: no result (needed kill, the SC2 client stayed open)
Bot2: no result (needed kill, the SC2 client stayed open)

#### Actual result after this PR
Ladder manager: Winner: Error, Result: Error
Bot1: no result (needed kill, the SC2 client stayed open)
Bot2: no result (needed kill, the SC2 client stayed open)

### Time out after 45 min

#### Expected behavior
Ladder manager: Winner: Tie, Result: Timeout
Bot1: Tie
Bot2: Tie

#### Used bots
Python_timeout vs Python_timeout

#### Actual result before this PR
Did not work. The LM did not interrupt the game after 45min in-game time.

#### Actual result after this PR
Ladder manager: Winner: Tie, Result: Timeout
Bot1: Tie
Bot2: Tie

### Bot2 has infinite loop at game loop 100

#### Expected behavior
Ladder manager: Winner: Bot1, Result: Player1Win
Bot1: Victory
Bot2: Defeat

#### Used bots
Python_ref vs Python_infinity_loop

#### Actual result before this PR
Ladder manager: Winner: Bot1, Result: Player2Crash
Bot1: no result (needed kill)
Bot2: no result (needed kill)

#### Actual result after this PR
Ladder manager: Winner: Bot1, Result: Player1Win (Maybe change this to Player2 crash?)
Bot1: Victory
Bot2: no result (needed kill)

## Neutral/Equal

### Time out due to in-game stalemate

#### Expected behavior
Ladder manager: Winner: Tie, Result: Tie
Bot1: Tie
Bot2: Tie

#### Used bots
Python_ref vs Python_ref

#### Actual result before this PR
Ladder manager: Winner: Tie, Result: Timeout
Bot1: Tie
Bot2: Tie

#### Actual result after this PR
Ladder manager: Winner: Tie, Result: Timeout
Bot1: Tie
Bot2: Tie

### Manually pressing surrender for Bot2

#### Expected behavior
Ladder manager: Winner: Bot1, Result: Player1Win
Bot1: Victory
Bot2: Defeat

#### Used bots
Python_workerrush vs Python_ref

#### Actual result before this PR
Ladder manager: Winner: Bot1, Result: Player1Win
Bot1: Victory
Bot2: no result

#### Actual result after this PR
Ladder manager: Winner: Bot1, Result: Player1Win
Bot1: Victory
Bot2: no result

## Worse

### Bot2 sends leave request at game loop 100

#### Expected behavior
Ladder manager: Winner: Bot1, Result: Player1Win
Bot1: Victory
Bot2: Defeat

#### Used bots
Python_ref vs Python_leave

#### Actual result before this PR
Ladder manager: Winner: Bot1, Result: Player1Win
Bot1: Victory
Bot2: Defeat

#### Actual result after this PR
Ladder manager: Winner: Bot1, Result: Player2Crash
Bot1: Victory
Bot2: Defeat

(I would argue it should be Player2Crash since people shouldn't use leave game requests, but the PR to accept "gg" chat commands is not there yet.)

